### PR TITLE
Allow to specify mink driver in browser configuration

### DIFF
--- a/library/aik099/PHPUnit/BrowserConfiguration/BrowserConfiguration.php
+++ b/library/aik099/PHPUnit/BrowserConfiguration/BrowserConfiguration.php
@@ -14,7 +14,6 @@ namespace aik099\PHPUnit\BrowserConfiguration;
 use aik099\PHPUnit\BrowserTestCase;
 use aik099\PHPUnit\Event\TestEndedEvent;
 use aik099\PHPUnit\Event\TestEvent;
-use aik099\PHPUnit\IEventDispatcherAware;
 use aik099\PHPUnit\Session\ISessionStrategyFactory;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
@@ -42,10 +41,21 @@ class BrowserConfiguration implements EventSubscriberInterface
 		'browserName' => 'firefox',
 		'desiredCapabilities' => array(),
 		'baseUrl' => '',
+		'driver' => 'selenium2',
+		'driverOptions' => array(),
 
 		// Test related.
 		'type' => 'default',
 		'sessionStrategy' => ISessionStrategyFactory::TYPE_ISOLATED,
+	);
+
+	/**
+	 * List of driver aliases. Used for validation in the setDriver() method.
+	 *
+	 * @var array
+	 */
+	protected $driverAliases = array(
+		'selenium2', 'goutte', 'sahi', 'zombie',
 	);
 
 	/**
@@ -212,6 +222,7 @@ class BrowserConfiguration implements EventSubscriberInterface
 		}
 
 		$this->setHost($parameters['host'])->setPort($parameters['port'])->setTimeout($parameters['timeout']);
+		$this->setDriver($parameters['driver']);
 		$this->setBrowserName($parameters['browserName'])->setDesiredCapabilities($parameters['desiredCapabilities']);
 		$this->setBaseUrl($parameters['baseUrl']);
 		$this->setSessionStrategy($parameters['sessionStrategy']);
@@ -353,6 +364,59 @@ class BrowserConfiguration implements EventSubscriberInterface
 	public function getBaseUrl()
 	{
 		return $this->parameters['baseUrl'];
+	}
+
+	/**
+	 * Set the Mink driver to use.
+	 *
+	 * @param string $driver The driver to use.
+	 *
+	 * @return self
+	 * @throws \InvalidArgumentException When Mink driver is not a string.
+	 */
+	public function setDriver($driver)
+	{
+		if ( !is_string($driver) ) {
+			throw new \InvalidArgumentException('The Mink driver must be a string');
+		}
+
+		$this->parameters['driver'] = $driver;
+
+		return $this;
+	}
+
+	/**
+	 * Returns the Mink driver.
+	 *
+	 * @return string
+	 */
+	public function getDriver()
+	{
+		return $this->parameters['driver'];
+	}
+
+	/**
+	 * Sets driver options to be used by the driver factory.
+	 *
+	 * @param array $driver_options Set Mink driver specific options.
+	 *
+	 * @return self
+	 */
+	public function setDriverOptions(array $driver_options)
+	{
+		$this->parameters['driverOptions'] = $driver_options;
+
+		return $this;
+	}
+
+	/**
+	 * Returns Mink driver options.
+	 *
+	 * @return array
+	 */
+	public function getDriverOptions()
+	{
+		return $this->parameters['driverOptions'];
 	}
 
 	/**

--- a/library/aik099/PHPUnit/MinkDriver/GoutteDriverFactory.php
+++ b/library/aik099/PHPUnit/MinkDriver/GoutteDriverFactory.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * This file is part of the phpunit-mink library.
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @copyright Alexander Obuhovich <aik.bold@gmail.com>
+ * @link      https://github.com/aik099/phpunit-mink
+ */
+
+
+namespace aik099\PHPUnit\MinkDriver;
+
+
+use aik099\PHPUnit\BrowserConfiguration\BrowserConfiguration;
+use Behat\Mink\Driver\GoutteDriver;
+
+class GoutteDriverFactory implements IMinkDriverFactory
+{
+
+	/**
+	 * Return a new instance of the Goutte driver.
+	 *
+	 * @param BrowserConfiguration $browser The browser configuration.
+	 *
+	 * @return GoutteDriver
+	 */
+	public function getInstance(BrowserConfiguration $browser)
+	{
+		return new GoutteDriver();
+	}
+
+}

--- a/library/aik099/PHPUnit/MinkDriver/IMinkDriverFactory.php
+++ b/library/aik099/PHPUnit/MinkDriver/IMinkDriverFactory.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * This file is part of the phpunit-mink library.
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @copyright Alexander Obuhovich <aik.bold@gmail.com>
+ * @link      https://github.com/aik099/phpunit-mink
+ */
+
+
+namespace aik099\PHPUnit\MinkDriver;
+
+
+use aik099\PHPUnit\BrowserConfiguration\BrowserConfiguration;
+use Behat\Mink\Driver\DriverInterface;
+
+interface IMinkDriverFactory
+{
+
+	/**
+	 * Return a new driver instance according to the
+	 * browser configuration.
+	 *
+	 * @param BrowserConfiguration $browser The browser configuration.
+	 *
+	 * @return DriverInterface
+	 */
+	public function getInstance(BrowserConfiguration $browser);
+
+}

--- a/library/aik099/PHPUnit/MinkDriver/SahiDriverFactory.php
+++ b/library/aik099/PHPUnit/MinkDriver/SahiDriverFactory.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * This file is part of the phpunit-mink library.
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @copyright Alexander Obuhovich <aik.bold@gmail.com>
+ * @link      https://github.com/aik099/phpunit-mink
+ */
+
+
+namespace aik099\PHPUnit\MinkDriver;
+
+
+use aik099\PHPUnit\BrowserConfiguration\BrowserConfiguration;
+use Behat\Mink\Driver\SahiDriver;
+
+class SahiDriverFactory implements IMinkDriverFactory
+{
+
+	/**
+	 * Return a new SahiDriver instance
+	 *
+	 * @param BrowserConfiguration $browser The browser configuration.
+	 *
+	 * @return SahiDriver
+	 */
+	public function getInstance(BrowserConfiguration $browser)
+	{
+		$connection = new \Behat\SahiClient\Connection(null, $browser->getHost(), $browser->getPort());
+		$driver = new SahiDriver($browser->getBrowserName(), new \Behat\SahiClient\Client($connection));
+
+		return $driver;
+	}
+
+}

--- a/library/aik099/PHPUnit/MinkDriver/Selenium2DriverFactory.php
+++ b/library/aik099/PHPUnit/MinkDriver/Selenium2DriverFactory.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * This file is part of the phpunit-mink library.
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @copyright Alexander Obuhovich <aik.bold@gmail.com>
+ * @link      https://github.com/aik099/phpunit-mink
+ */
+
+
+namespace aik099\PHPUnit\MinkDriver;
+
+
+use aik099\PHPUnit\BrowserConfiguration\BrowserConfiguration;
+use Behat\Mink\Driver\Selenium2Driver;
+
+class Selenium2DriverFactory implements IMinkDriverFactory
+{
+
+	/**
+	 * Instantiate and return the selenium 2 driver instance.
+	 *
+	 * @param BrowserConfiguration $browser The browser configuration.
+	 *
+	 * @return Selenium2Driver
+	 */
+	public function getInstance(BrowserConfiguration $browser)
+	{
+		$browser_name = $browser->getBrowserName();
+		$capabilities = $browser->getDesiredCapabilities();
+		$capabilities['browserName'] = $browser_name;
+
+		// TODO: maybe doesn't work!
+		ini_set('default_socket_timeout', $browser->getTimeout());
+
+		$driver = new Selenium2Driver(
+			$browser_name,
+			$capabilities,
+			'http://' . $browser->getHost() . ':' . $browser->getPort() . '/wd/hub'
+		);
+
+		return $driver;
+	}
+
+}

--- a/library/aik099/PHPUnit/MinkDriver/ZombieDriverFactory.php
+++ b/library/aik099/PHPUnit/MinkDriver/ZombieDriverFactory.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * This file is part of the phpunit-mink library.
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @copyright Alexander Obuhovich <aik.bold@gmail.com>
+ * @link      https://github.com/aik099/phpunit-mink
+ */
+
+
+namespace aik099\PHPUnit\MinkDriver;
+
+
+use aik099\PHPUnit\BrowserConfiguration\BrowserConfiguration;
+use Behat\Mink\Driver\NodeJS\Server\ZombieServer;
+use Behat\Mink\Driver\ZombieDriver;
+
+class ZombieDriverFactory implements IMinkDriverFactory
+{
+
+	/**
+	 * Return a new instance of the Zombie driver.
+	 *
+	 * @param BrowserConfiguration $browser The browser configuration.
+	 *
+	 * @return ZombieDriver
+	 */
+	public function getInstance(BrowserConfiguration $browser)
+	{
+		$options = $browser->getDriverOptions();
+		$node_bin = isset($options['node_binary']) ? $options['node_binary'] : null;
+
+		return new ZombieDriver(
+			new ZombieServer($browser->getHost(), $browser->getPort(), $node_bin)
+		);
+	}
+
+}

--- a/library/aik099/PHPUnit/Session/SessionFactory.php
+++ b/library/aik099/PHPUnit/Session/SessionFactory.php
@@ -12,8 +12,8 @@ namespace aik099\PHPUnit\Session;
 
 
 use aik099\PHPUnit\BrowserConfiguration\BrowserConfiguration;
+use aik099\PHPUnit\MinkDriver\IMinkDriverFactory;
 use Behat\Mink\Driver\DriverInterface;
-use Behat\Mink\Driver\Selenium2Driver;
 use Behat\Mink\Session;
 
 /**
@@ -23,6 +23,37 @@ use Behat\Mink\Session;
  */
 class SessionFactory implements ISessionFactory
 {
+
+	/**
+	 * The driver factory registry.
+	 *
+	 * @var IMinkDriverFactory[]
+	 */
+	private $_driverFactoryRegistry = array();
+
+	/**
+	 * The default driver factories. Only those present will be added to the $_driverFactoryRegistry array.
+	 *
+	 * @var string[]
+	 */
+	private $_defaultDriverFactories = array(
+		'selenium2' => 'aik099\PHPUnit\MinkDriver\Selenium2DriverFactory',
+		'sahi' => 'aik099\PHPUnit\MinkDriver\SahiDriverFactory',
+		'goutte' => 'aik099\PHPUnit\MinkDriver\GoutteDriverFactory',
+		'zombie' => 'aik099\PHPUnit\MinkDriver\ZombieDriverFactory',
+	);
+
+	/**
+	 * Initialize the driver factory registry array.
+	 */
+	public function __construct()
+	{
+		foreach ( $this->_defaultDriverFactories as $alias => $factory_class ) {
+			if ( class_exists($factory_class) ) {
+				$this->registerDriverFactory($alias, new $factory_class());
+			}
+		}
+	}
 
 	/**
 	 * Creates new session based on browser configuration.
@@ -45,20 +76,60 @@ class SessionFactory implements ISessionFactory
 	 */
 	private function _createDriver(BrowserConfiguration $browser)
 	{
-		$browser_name = $browser->getBrowserName();
-		$capabilities = $browser->getDesiredCapabilities();
-		$capabilities['browserName'] = $browser_name;
+		$driver_alias = $browser->getDriver();
 
-		// TODO: maybe doesn't work!
-		ini_set('default_socket_timeout', $browser->getTimeout());
+		if ( !array_key_exists($driver_alias, $this->_driverFactoryRegistry) ) {
+			throw new \OutOfBoundsException(sprintf('No driver factory for driver "%s"', $driver_alias));
+		}
 
-		$driver = new Selenium2Driver(
-			$browser_name,
-			$capabilities,
-			'http://' . $browser->getHost() . ':' . $browser->getPort() . '/wd/hub'
-		);
+		$factory = $this->_getDriverFactory($driver_alias);
 
-		return $driver;
+		return $factory->getInstance($browser);
+	}
+
+	/**
+	 * Lazy instantiation of the driver factory.
+	 *
+	 * @param string $driver_alias The driver alias for the driver factory.
+	 *
+	 * @return IMinkDriverFactory
+	 */
+	private function _getDriverFactory($driver_alias)
+	{
+		if ( is_string($this->_driverFactoryRegistry[$driver_alias]) ) {
+			$this->_driverFactoryRegistry[$driver_alias] = new $this->_driverFactoryRegistry[$driver_alias]();
+		}
+
+		return $this->_driverFactoryRegistry[$driver_alias];
+	}
+
+	/**
+	 * Register a new mink driver factory by either specifying the class name or an instance.
+	 *
+	 * @param string             $driver_alias   The driver alias.
+	 * @param IMinkDriverFactory $driver_factory The driver factory class or instance.
+	 *
+	 * @return void
+	 * @throws \InvalidArgumentException If the driver alias is not a string.
+	 */
+	public function registerDriverFactory($driver_alias, IMinkDriverFactory $driver_factory)
+	{
+		$this->_validateDriverAlias($driver_alias);
+		$this->_driverFactoryRegistry[$driver_alias] = $driver_factory;
+	}
+
+	/**
+	 * Validate the driver alias.
+	 *
+	 * @param string $driver_alias The driver alias.
+	 *
+	 * @return void
+	 */
+	private function _validateDriverAlias($driver_alias)
+	{
+		if ( !is_string($driver_alias) ) {
+			throw new \InvalidArgumentException('The Mink driver alias must be a string.');
+		}
 	}
 
 }

--- a/tests/aik099/PHPUnit/BrowserConfiguration/BrowserConfigurationTest.php
+++ b/tests/aik099/PHPUnit/BrowserConfiguration/BrowserConfigurationTest.php
@@ -80,6 +80,8 @@ class BrowserConfigurationTest extends EventDispatcherAwareTestCase
 			'desiredCapabilities' => array('platform' => 'Windows 7', 'version' => 10),
 			'baseUrl' => 'http://other-host',
 			'sessionStrategy' => ISessionStrategyFactory::TYPE_SHARED,
+			'driver' => 'selenium2',
+			'driverOptions' => array(),
 		);
 
 		$this->browser = $this->createBrowserConfiguration(
@@ -220,6 +222,8 @@ class BrowserConfigurationTest extends EventDispatcherAwareTestCase
 		$this->assertSame($this->setup['desiredCapabilities'], $this->browser->getDesiredCapabilities());
 		$this->assertSame($this->setup['baseUrl'], $this->browser->getBaseUrl());
 		$this->assertSame($this->setup['sessionStrategy'], $this->browser->getSessionStrategy());
+		$this->assertSame($this->setup['driver'], $this->browser->getDriver());
+		$this->assertSame($this->setup['driverOptions'], $this->browser->getDriverOptions());
 	}
 
 	/**
@@ -459,6 +463,31 @@ class BrowserConfigurationTest extends EventDispatcherAwareTestCase
 
 		$this->browser->setSessionStrategy(ISessionStrategyFactory::TYPE_SHARED);
 		$this->assertTrue($this->browser->getTestStatus($test_case, $test_result));
+	}
+
+	/**
+	 * @expectedException \InvalidArgumentException
+	 * @expectedExceptionMessage The Mink driver must be a string
+	 *
+	 * @return void
+	 */
+	public function testSetDriverMustReceiveString()
+	{
+		$this->browser->setDriver(array());
+	}
+
+	public function testDriverClassIsCopiedBySetup()
+	{
+		$driver_name = 'selenium2';
+		$this->browser->setup(array('driver' => $driver_name));
+		$this->assertEquals($driver_name, $this->browser->getDriver());
+	}
+
+	public function testSetDriverOptions()
+	{
+		$driver_options = array('test driver', 'options');
+		$this->browser->setDriverOptions($driver_options);
+		$this->assertSame($driver_options, $this->browser->getDriverOptions());
 	}
 
 	/**

--- a/tests/aik099/PHPUnit/MinkDriver/GoutteDriverFactoryTest.php
+++ b/tests/aik099/PHPUnit/MinkDriver/GoutteDriverFactoryTest.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * This file is part of the phpunit-mink library.
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @copyright Alexander Obuhovich <aik.bold@gmail.com>
+ * @link      https://github.com/aik099/phpunit-mink
+ */
+
+
+namespace tests\aik099\PHPUnit\MinkDriver;
+
+
+use aik099\PHPUnit\MinkDriver\GoutteDriverFactory;
+use Mockery as m;
+
+class GoutteDriverFactoryTest extends \PHPUnit_Framework_TestCase
+{
+
+	/**
+	 * @var string
+	 */
+	private $_driverClass = 'Behat\\Mink\\Driver\\GoutteDriver';
+
+	/**
+	 * @var GoutteDriverFactory;
+	 */
+	private $_factory;
+
+	public function setUp()
+	{
+		if ( !class_exists($this->_driverClass) ) {
+			$this->markTestSkipped(sprintf('Mink driver not installed: "%s"', $this->_driverClass));
+		}
+
+		$this->_factory = new GoutteDriverFactory();
+	}
+
+	public function testItImplementsTheDriverFactoryInterface()
+	{
+		$this->assertInstanceOf('aik099\\PHPUnit\\MinkDriver\\IMinkDriverFactory', $this->_factory);
+	}
+
+	public function testItReturnsAGoutteDriver()
+	{
+		$browser = m::mock('aik099\\PHPUnit\\BrowserConfiguration\\BrowserConfiguration');
+		$this->assertInstanceOf($this->_driverClass, $this->_factory->getInstance($browser));
+	}
+
+}

--- a/tests/aik099/PHPUnit/MinkDriver/SahiDriverFactoryTest.php
+++ b/tests/aik099/PHPUnit/MinkDriver/SahiDriverFactoryTest.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * This file is part of the phpunit-mink library.
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @copyright Alexander Obuhovich <aik.bold@gmail.com>
+ * @link      https://github.com/aik099/phpunit-mink
+ */
+
+
+namespace tests\aik099\PHPUnit\MinkDriver;
+
+
+use aik099\PHPUnit\MinkDriver\SahiDriverFactory;
+use Mockery as m;
+
+class SahiDriverFactoryTest extends \PHPUnit_Framework_TestCase
+{
+
+	/**
+	 * @var string
+	 */
+	private $_driverClass = 'Behat\\Mink\\Driver\\SahiDriver';
+
+	/**
+	 * @var SahiDriverFactory;
+	 */
+	private $_factory;
+
+	public function setUp()
+	{
+		if ( !class_exists($this->_driverClass) ) {
+			$this->markTestSkipped(sprintf('Mink driver not installed: "%s"', $this->_driverClass));
+		}
+
+		$this->_factory = new SahiDriverFactory();
+	}
+
+	public function testItImplementsTheDriverFactoryInterface()
+	{
+		$this->assertInstanceOf('aik099\\PHPUnit\\MinkDriver\\IMinkDriverFactory', $this->_factory);
+	}
+
+	public function testItReturnsASahiDriver()
+	{
+		$browser = m::mock('aik099\\PHPUnit\\BrowserConfiguration\\BrowserConfiguration');
+		$browser->shouldReceive('getBrowserName')->once()->andReturn('firefox');
+		$browser->shouldReceive('getHost')->once()->andReturn('');
+		$browser->shouldReceive('getPort')->once()->andReturn(0);
+		$this->assertInstanceOf($this->_driverClass, $this->_factory->getInstance($browser));
+	}
+
+}

--- a/tests/aik099/PHPUnit/MinkDriver/Selenium2DriverFactoryTest.php
+++ b/tests/aik099/PHPUnit/MinkDriver/Selenium2DriverFactoryTest.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * This file is part of the phpunit-mink library.
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @copyright Alexander Obuhovich <aik.bold@gmail.com>
+ * @link      https://github.com/aik099/phpunit-mink
+ */
+
+
+namespace tests\aik099\PHPUnit\MinkDriver;
+
+
+use aik099\PHPUnit\MinkDriver\Selenium2DriverFactory;
+use Mockery as m;
+
+class Selenium2DriverFactoryTest extends \PHPUnit_Framework_TestCase
+{
+
+	/**
+	 * @var string
+	 */
+	private $_driverClass = 'Behat\\Mink\\Driver\\Selenium2Driver';
+
+	/**
+	 * @var Selenium2DriverFactory;
+	 */
+	private $_factory;
+
+	public function setUp()
+	{
+		if ( !class_exists($this->_driverClass) ) {
+			$this->markTestSkipped(sprintf('Mink driver not installed: "%s"', $this->_driverClass));
+		}
+
+		$this->_factory = new Selenium2DriverFactory();
+	}
+
+	public function testItImplementsTheDriverFactoryInterface()
+	{
+		$this->assertInstanceOf('aik099\\PHPUnit\\MinkDriver\\IMinkDriverFactory', $this->_factory);
+	}
+
+	public function testItReturnsASelenium2Driver()
+	{
+		$browser = m::mock('aik099\\PHPUnit\\BrowserConfiguration\\BrowserConfiguration');
+		$browser->shouldReceive('getDesiredCapabilities')->once()->andReturn(array());
+		$browser->shouldReceive('getBrowserName')->once()->andReturn('');
+		$browser->shouldReceive('getTimeout')->once()->andReturn(0);
+		$browser->shouldReceive('getHost')->once()->andReturn('');
+		$browser->shouldReceive('getPort')->once()->andReturn(0);
+		$this->assertInstanceOf($this->_driverClass, $this->_factory->getInstance($browser));
+	}
+
+}

--- a/tests/aik099/PHPUnit/MinkDriver/ZombieDriverFactoryTest.php
+++ b/tests/aik099/PHPUnit/MinkDriver/ZombieDriverFactoryTest.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * This file is part of the phpunit-mink library.
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @copyright Alexander Obuhovich <aik.bold@gmail.com>
+ * @link      https://github.com/aik099/phpunit-mink
+ */
+
+
+namespace tests\aik099\PHPUnit\MinkDriver;
+
+
+use aik099\PHPUnit\MinkDriver\ZombieDriverFactory;
+use Mockery as m;
+
+class ZombieDriverFactoryTest extends \PHPUnit_Framework_TestCase
+{
+
+	/**
+	 * @var string
+	 */
+	private $_driverClass = 'Behat\\Mink\\Driver\\ZombieDriver';
+
+	/**
+	 * @var ZombieDriverFactory;
+	 */
+	private $_factory;
+
+	public function setUp()
+	{
+		if ( !class_exists($this->_driverClass) ) {
+			$this->markTestSkipped(sprintf('Mink driver not installed: "%s"', $this->_driverClass));
+		}
+
+		$this->_factory = new ZombieDriverFactory();
+	}
+
+	public function testItImplementsTheDriverFactoryInterface()
+	{
+		$this->assertInstanceOf('aik099\\PHPUnit\\MinkDriver\\IMinkDriverFactory', $this->_factory);
+	}
+
+	public function testItReturnsAZombieDriver()
+	{
+		$browser = m::mock('aik099\\PHPUnit\\BrowserConfiguration\\BrowserConfiguration');
+		$browser->shouldReceive('getDriverOptions')->once()->andReturn(array());
+		$browser->shouldReceive('getHost')->once()->andReturn('');
+		$browser->shouldReceive('getPort')->once()->andReturn(0);
+		$this->assertInstanceOf($this->_driverClass, $this->_factory->getInstance($browser));
+	}
+
+}

--- a/tests/aik099/PHPUnit/Session/SessionFactoryTest.php
+++ b/tests/aik099/PHPUnit/Session/SessionFactoryTest.php
@@ -49,11 +49,65 @@ class SessionFactoryTest extends \PHPUnit_Framework_TestCase
 		$browser->shouldReceive('getTimeout')->once()->andReturn(0);
 		$browser->shouldReceive('getHost')->once()->andReturn('');
 		$browser->shouldReceive('getPort')->once()->andReturn(0);
+		$browser->shouldReceive('getDriver')->once()->andReturn('selenium2');
 
 		$session = $this->_factory->createSession($browser);
 
 		$this->assertInstanceOf('Behat\\Mink\\Session', $session);
 		$this->assertInstanceOf('Behat\\Mink\\Driver\\Selenium2Driver', $session->getDriver());
+	}
+
+	/**
+	 * @expectedException \OutOfBoundsException
+	 * @expectedExceptionMessage No driver factory for driver
+	 */
+	public function testItThrowsExceptionForUnknownDriverAlias()
+	{
+		$browser = m::mock('aik099\\PHPUnit\\BrowserConfiguration\\BrowserConfiguration');
+		$browser->shouldReceive('getDriver')->once()->andReturn('invalid');
+
+		$this->_factory->createSession($browser);
+	}
+
+	/**
+	 * @dataProvider driversAvailableByDefaultProvider
+	 */
+	public function testDriversRegisteredByDefault($driver, $expected_driver)
+	{
+		if ( !class_exists($expected_driver) ) {
+			$this->markTestSkipped(
+				sprintf('Test skipped because Mink driver is not installed: "%s"', $expected_driver)
+			);
+		}
+
+		$browser = m::mock('aik099\\PHPUnit\\BrowserConfiguration\\BrowserConfiguration');
+		$browser->shouldReceive('getDesiredCapabilities')->andReturn(array());
+		$browser->shouldReceive('getBrowserName')->andReturn('');
+		$browser->shouldReceive('getTimeout')->andReturn(0);
+		$browser->shouldReceive('getHost')->andReturn('');
+		$browser->shouldReceive('getPort')->andReturn(0);
+		$browser->shouldReceive('getDriverOptions')->andReturn(array());
+		$browser->shouldReceive('getDriver')->once()->andReturn($driver);
+
+		$session = $this->_factory->createSession($browser);
+		$this->assertInstanceOf($expected_driver, $session->getDriver());
+	}
+
+	public function driversAvailableByDefaultProvider()
+	{
+		return array(
+			'selenium2' => array('selenium2', 'Behat\\Mink\\Driver\\Selenium2Driver'),
+			'sahi' => array('sahi', 'Behat\\Mink\\Driver\\SahiDriver'),
+			'goutte' => array('goutte', 'Behat\\Mink\\Driver\\GoutteDriver'),
+			'zombie' => array('zombie', 'Behat\\Mink\\Driver\\ZombieDriver'),
+		);
+	}
+
+	public function testItRegistersTheDriverFactory()
+	{
+		$stub_factory = m::mock('aik099\\PHPUnit\\MinkDriver\\IMinkDriverFactory');
+		$this->_factory->registerDriverFactory('test', $stub_factory);
+		$this->assertAttributeContains($stub_factory, '_driverFactoryRegistry', $this->_factory);
 	}
 
 }


### PR DESCRIPTION
* Add option to specify the mink driver as part of the browser configuration.
* For backward compatibility defaults to Selenium2Driver.
* Add Goutte and SahiDriver support.
* Allows to register additional mink drivers.

For example, to configure a test to run with the Goutte driver, use

```php
    public static $browsers = [[
        'browserName' => 'Goutte',
        'minkDriverClass' => 'Behat\\Mink\\Driver\\GoutteDriver'
    ]];
```

Closes #12