### PR TITLE
Don't run SauceLabs tests, when no API credentials are specified

### DIFF
--- a/library/aik099/PHPUnit/BrowserConfiguration/ApiBrowserConfiguration.php
+++ b/library/aik099/PHPUnit/BrowserConfiguration/ApiBrowserConfiguration.php
@@ -208,7 +208,9 @@ abstract class ApiBrowserConfiguration extends BrowserConfiguration
 
 		parent::onTestEnded($event);
 
-		if ( $event->getSession() === null ) {
+		$session = $event->getSession();
+
+		if ( $session === null || !$session->isStarted() ) {
 			// Session wasn't used in particular test.
 			return;
 		}
@@ -216,7 +218,7 @@ abstract class ApiBrowserConfiguration extends BrowserConfiguration
 		$test_case = $event->getTestCase();
 
 		$this->getAPIClient()->updateStatus(
-			$this->getSessionId($event->getSession()),
+			$this->getSessionId($session),
 			$this->getTestStatus($test_case, $event->getTestResult())
 		);
 	}

--- a/tests/aik099/PHPUnit/Integration/DataProviderTest.php
+++ b/tests/aik099/PHPUnit/Integration/DataProviderTest.php
@@ -50,6 +50,18 @@ class DataProviderTest extends BrowserTestCase
 		}
 	}
 
+	/**
+	 * Whatever or not code coverage information should be gathered.
+	 *
+	 * @return boolean
+	 * @throws \RuntimeException When used before test is started.
+	 */
+	public function getCollectCodeCoverageInformation()
+	{
+		// FIXME: Workaround for https://github.com/minkphp/phpunit-mink/issues/35 bug.
+		return false;
+	}
+
 	protected function customMethod()
 	{
 		return 5;


### PR DESCRIPTION
I've also identified and fixed an issue, when event listener in test was using wrong priority and resulted in test to always fail.

Closes #18