### PR TITLE
Increase timeout for `testCreateBrowserConfiguration` test

### DIFF
--- a/tests/aik099/PHPUnit/BrowserConfiguration/BrowserConfigurationFactoryTest.php
+++ b/tests/aik099/PHPUnit/BrowserConfiguration/BrowserConfigurationFactoryTest.php
@@ -47,6 +47,7 @@ class BrowserConfigurationFactoryTest extends EventDispatcherAwareTestCase
 	 * @param string $type           Type.
 	 *
 	 * @return void
+	 * @medium
 	 * @dataProvider createBrowserConfigurationDataProvider
 	 */
 	public function testCreateBrowserConfiguration(array $browser_config, $type)


### PR DESCRIPTION
I've marked test with `@medium` annotation to indicate that it can take longer then 1 second to execute.

I suspect that this has something to do with Travis CI that this particular test fails to complete within 1 second.

Closes #37