### PR TITLE
Complete support for BrowserStack

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,8 @@ env:
         - BUILD_TYPE=code
         - secure: HhIy0kN0+UbuLeaVBk7O/utAYo038a9Emr8cdcfU+LQTu6CfGEbifH+LddXs6M/bSLTdNUSwQSnwycbeNYZ6iHCO/JI/vEgKxCTSecPerMXBIVCQjFZaCp3Tev8JJ40hKe78WJ/d0G4bGtIR6atR5V+H8Z29iwJeFtCj6doEt3o=
         - secure: oLadQTqg8HSEmUC0qEtChKd/R0ZiFNhzoZjIaa8kAJ0fjln/2xfNCBQIg4YstyjFy2kLiP6Lg8xW/RZljzyTHC+MCB9NNqTYjKLqFNRvFOlZUOnrAwc4sl4qjMYu9klWKa+rfyZzsuVWn++g829s2lFopkImqa6EB9DOR2TOT6w=
+        - secure: Tsh/Vvb9auy672eRf0xbN8fKDr8OYzjRkZDHiaYc5yH49UkoromwPaC74mJtM5KxFOYalrC+GzwOSuvzT8RYO/XwTuk6IGw9P/0v0qMCaSLkjaRzerwVH1L3RPgDokqDnCHAgSzkAlg8d5o0MWBlbxaYiaKL4LmEKGwxQjrW590=
+        - secure: HQQ1FY27tpn0Idy+NDYXdbnMjHKIOsZoE59qYfs18euS0zM559gcuMk4OQ/J2lcDFmdb6vjSFlznwH+6iVyoLuC5WAP3JGQ3UXSJ+7huRV/eDI6WepmEymjEOSWvTT+RYpmQu1lQWC2Y3zBCVbVT7sbVsqXvmuR2daBL11dpU+g=
 
 addons:
     sauce_connect: true

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -11,7 +11,7 @@ method in of test case class and setting it via ``setBrowser`` method.
 
 .. literalinclude:: examples/configuration/config_via_setup_method.php
    :linenos:
-   :emphasize-lines: 11,16,25-29,32
+   :emphasize-lines: 11,16,25,34-38,41
 
 Per Test Case Configuration
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -52,7 +52,7 @@ Name                     Description
                          that will be used by Selenium server
 ``baseUrl``              base url of website, that is tested
 ``sessionStrategy``      used session strategy (defaults to ``isolated``)
-``type``                 type of configuration (defaults to ``default``, but can also be ``saucelabs``)
+``type``                 type of configuration (defaults to ``default``, but can also be ``saucelabs`` or ``browserstack``)
 ``api_username``         API username of used service (applicable to any but ``default`` configuration type)
 ``api_key``              API key of used service (applicable to any but ``default`` configuration type)
 =======================  =================================================================================================

--- a/docs/examples/configuration/config_via_setup_method.php
+++ b/docs/examples/configuration/config_via_setup_method.php
@@ -21,6 +21,15 @@ class PerTestBrowserConfigTest extends BrowserTestCase
             // optional options goes here
         ));
 
+        // To create "BrowserStack" browser configuration via BrowserConfigurationFactory.
+        $browser = $this->createBrowserConfiguration(array(
+            // required
+            'type' => 'browserstack',
+            'api_username' => 'bs_username',
+            'api_key' => 'bs_api_key',
+            // optional options goes here
+        ));
+
         // Options can be changed later (optional).
         $browser->setHost('selenium_host')->setPort('selenium_port')->setTimeout(30);
         $browser->setBrowserName('browser name')->setDesiredCapabilities(array(

--- a/docs/examples/getting-started/cloud_selenium_configs.php
+++ b/docs/examples/getting-started/cloud_selenium_configs.php
@@ -2,13 +2,21 @@
 
 use aik099\PHPUnit\BrowserTestCase;
 
-class SauceLabsTest extends BrowserTestCase
+class BrowserConfigExampleTest extends BrowserTestCase
 {
 
     public static $browsers = array(
         // Sauce Labs browser configuration.
         array(
             'type' => 'saucelabs',
+            'api_username' => '...',
+            'api_key' => '...',
+            'browserName' => 'firefox',
+            'baseUrl' => 'http://www.google.com',
+        ),
+        // BrowserStack browser configuration.
+        array(
+            'type' => 'browserstack',
             'api_username' => '...',
             'api_key' => '...',
             'browserName' => 'firefox',

--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -34,20 +34,22 @@ Basic Usage
    :linenos:
    :emphasize-lines: 5,8,20,34
 
-Using "Sauce Labs"
-^^^^^^^^^^^^^^^^^^
-When using `Sauce Labs <https://saucelabs.com/>`_ account to perform Selenium server-based testing you need to
+Selenium in Cloud
+^^^^^^^^^^^^^^^^^
+When using Selenium-based solution for automated testing in the cloud (e.g. `Sauce Labs`_ or `BrowserStack`_) you need to
 specify following settings:
 
-* ``'type' => 'saucelabs'``
+* ``'type' => 'saucelabs'`` or ``'type' => 'browserstack'``
 * ``'api_username' => '...'``
 * ``'api_key' => '...'``
 
 instead of ``host`` and ``port`` settings. In all other aspects everything will work the same as if all
 tests were running locally.
 
-.. literalinclude:: examples/getting-started/sauce_labs.php
+.. literalinclude:: examples/getting-started/cloud_selenium_configs.php
    :linenos:
-   :emphasize-lines: 11-13
+   :emphasize-lines: 11-13,19-21
 
 .. _`Mink`: https://github.com/Behat/Mink
+.. _`Sauce Labs`: https://saucelabs.com/
+.. _`BrowserStack`: http://www.browserstack.com/

--- a/library/aik099/PHPUnit/APIClient/BrowserStackAPIClient.php
+++ b/library/aik099/PHPUnit/APIClient/BrowserStackAPIClient.php
@@ -52,18 +52,33 @@ class BrowserStackAPIClient implements IAPIClient
 	}
 
 	/**
+	 * Returns information about session.
+	 *
+	 * @param string $session_id Session ID.
+	 *
+	 * @return array
+	 */
+	public function getInfo($session_id)
+	{
+		$result = $this->execute('GET', 'sessions/' . $session_id . '.json');
+
+		return $result['automation_session'];
+	}
+
+	/**
 	 * Update status of the test, that was executed in the given session.
 	 *
 	 * @param string  $session_id  Session ID.
 	 * @param boolean $test_status Test status.
 	 *
-	 * @return boolean
+	 * @return array
 	 */
 	public function updateStatus($session_id, $test_status)
 	{
 		$data = array('status' => $test_status ? 'completed' : 'error');
+		$result = $this->execute('PUT', 'sessions/' . $session_id . '.json', $data);
 
-		return $this->execute('PUT', 'sessions/' . $session_id . '.json', json_encode($data));
+		return $result['automation_session'];
 	}
 
 	/**

--- a/library/aik099/PHPUnit/APIClient/IAPIClient.php
+++ b/library/aik099/PHPUnit/APIClient/IAPIClient.php
@@ -18,12 +18,21 @@ interface IAPIClient
 {
 
 	/**
+	 * Returns information about session.
+	 *
+	 * @param string $session_id Session ID.
+	 *
+	 * @return array
+	 */
+	public function getInfo($session_id);
+
+	/**
 	 * Update status of the test, that was executed in the given session.
 	 *
 	 * @param string  $session_id  Session ID.
 	 * @param boolean $test_status Test status.
 	 *
-	 * @return boolean
+	 * @return array
 	 */
 	public function updateStatus($session_id, $test_status);
 

--- a/library/aik099/PHPUnit/APIClient/SauceLabsAPIClient.php
+++ b/library/aik099/PHPUnit/APIClient/SauceLabsAPIClient.php
@@ -34,12 +34,24 @@ class SauceLabsAPIClient implements IAPIClient
 	}
 
 	/**
+	 * Returns information about session.
+	 *
+	 * @param string $session_id Session ID.
+	 *
+	 * @return array
+	 */
+	public function getInfo($session_id)
+	{
+		return $this->_sauceRest->getJob($session_id);
+	}
+
+	/**
 	 * Update status of the test, that was executed in the given session.
 	 *
 	 * @param string  $session_id  Session ID.
 	 * @param boolean $test_status Test status.
 	 *
-	 * @return boolean
+	 * @return array
 	 */
 	public function updateStatus($session_id, $test_status)
 	{

--- a/library/aik099/PHPUnit/BrowserConfiguration/ApiBrowserConfiguration.php
+++ b/library/aik099/PHPUnit/BrowserConfiguration/ApiBrowserConfiguration.php
@@ -228,7 +228,7 @@ abstract class ApiBrowserConfiguration extends BrowserConfiguration
 	 *
 	 * @return IAPIClient
 	 */
-	protected function getAPIClient()
+	public function getAPIClient()
 	{
 		return $this->browserConfigurationFactory->createAPIClient($this);
 	}

--- a/library/aik099/PHPUnit/BrowserConfiguration/BrowserStackBrowserConfiguration.php
+++ b/library/aik099/PHPUnit/BrowserConfiguration/BrowserStackBrowserConfiguration.php
@@ -11,6 +11,7 @@
 namespace aik099\PHPUnit\BrowserConfiguration;
 
 
+use aik099\PHPUnit\Event\TestEvent;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 /**
@@ -37,6 +38,31 @@ class BrowserStackBrowserConfiguration extends ApiBrowserConfiguration
 	}
 
 	/**
+	 * Hook, called from "BrowserTestCase::setUp" method.
+	 *
+	 * @param TestEvent $event Test event.
+	 *
+	 * @return void
+	 */
+	public function onTestSetup(TestEvent $event)
+	{
+		if ( !$event->validateSubscriber($this->getTestCase()) ) {
+			return;
+		}
+
+		parent::onTestSetup($event);
+
+		$desired_capabilities = $this->getDesiredCapabilities();
+
+		if ( getenv('TRAVIS_JOB_NUMBER') ) {
+			$desired_capabilities['browserstack.local'] = 'true';
+			$desired_capabilities['browserstack.localIdentifier'] = getenv('TRAVIS_JOB_NUMBER');
+		}
+
+		$this->setDesiredCapabilities($desired_capabilities);
+	}
+
+	/**
 	 * Returns hostname from browser configuration.
 	 *
 	 * @return string
@@ -58,7 +84,7 @@ class BrowserStackBrowserConfiguration extends ApiBrowserConfiguration
 
 		if ( !isset($capabilities['os']) ) {
 			$capabilities['os'] = 'Windows';
-			$capabilities['os_version'] = 'XP';
+			$capabilities['os_version'] = '7';
 		}
 
 		if ( !isset($capabilities['acceptSslCerts']) ) {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -28,6 +28,8 @@
 		<!--
 			<env name="SAUCE_USERNAME" value=""/>
 			<env name="SAUCE_ACCESS_KEY" value=""/>
+			<env name="BS_USERNAME" value=""/>
+			<env name="BS_ACCESS_KEY" value=""/>
 		-->
 	</php>
 

--- a/tests/aik099/PHPUnit/BrowserConfiguration/BrowserStackBrowserConfigurationTest.php
+++ b/tests/aik099/PHPUnit/BrowserConfiguration/BrowserStackBrowserConfigurationTest.php
@@ -27,10 +27,15 @@ class BrowserStackBrowserConfigurationTest extends ApiBrowserConfigurationTestCa
 	{
 		$this->browserConfigurationClass = 'aik099\\PHPUnit\\BrowserConfiguration\\BrowserStackBrowserConfiguration';
 
+		$this->tunnelCapabilities = array(
+			'browserstack.local' => 'true',
+			'browserstack.localIdentifier' => 'env:TRAVIS_JOB_NUMBER',
+		);
+
 		parent::setUp();
 
 		$this->setup['desiredCapabilities'] = array(
-			'os' => 'Windows', 'os_version' => '7', 'version' => 10,
+			'os' => 'Windows', 'os_version' => 'XP', 'version' => 10,
 			'acceptSslCerts' => 'true',
 		);
 		$this->setup['host'] = 'UN:AK@hub.browserstack.com';
@@ -63,7 +68,7 @@ class BrowserStackBrowserConfigurationTest extends ApiBrowserConfigurationTestCa
 			),
 			array(
 				array('acceptSslCerts' => 'false'),
-				array('acceptSslCerts' => 'false', 'os' => 'Windows', 'os_version' => 'XP'),
+				array('acceptSslCerts' => 'false', 'os' => 'Windows', 'os_version' => '7'),
 			),
 		);
 	}

--- a/tests/aik099/PHPUnit/BrowserConfiguration/SauceLabsBrowserConfigurationTest.php
+++ b/tests/aik099/PHPUnit/BrowserConfiguration/SauceLabsBrowserConfigurationTest.php
@@ -29,67 +29,15 @@ class SauceLabsBrowserConfigurationTest extends ApiBrowserConfigurationTestCase
 	 */
 	protected function setUp()
 	{
-		$this->testsRequireSubscriber[] = 'testTunnelIdentifier';
 		$this->browserConfigurationClass = 'aik099\\PHPUnit\\BrowserConfiguration\\SauceLabsBrowserConfiguration';
+
+		$this->tunnelCapabilities = array(
+			'tunnel-identifier' => 'env:TRAVIS_JOB_NUMBER',
+		);
 
 		parent::setUp();
 
 		$this->setup['host'] = 'UN:AK@ondemand.saucelabs.com';
-	}
-
-	/**
-	 * Test description.
-	 *
-	 * @param string|null $travis_job_number Travis Job Number.
-	 *
-	 * @return void
-	 * @dataProvider tunnelIdentifierDataProvider
-	 */
-	public function testTunnelIdentifier($travis_job_number = null)
-	{
-		// Reset any global env vars that might be left from previous tests.
-		$hhvm_hack = defined('HHVM_VERSION') ? '=' : '';
-		putenv('TRAVIS_JOB_NUMBER' . $hhvm_hack);
-
-		if ( isset($travis_job_number) ) {
-			putenv('TRAVIS_JOB_NUMBER=' . $travis_job_number);
-		}
-
-		$this->browser->setSessionStrategy(ISessionStrategyFactory::TYPE_ISOLATED);
-
-		$test_case = $this->createTestCase('TEST_NAME');
-		$test_case->shouldReceive('toString')->andReturn('TEST_NAME');
-
-		$event_dispatcher = new EventDispatcher();
-		$event_dispatcher->addSubscriber($this->browser);
-
-		$event_dispatcher->dispatch(
-			BrowserTestCase::TEST_SETUP_EVENT,
-			new TestEvent($test_case, m::mock('Behat\\Mink\\Session'))
-		);
-
-		$desired_capabilities = $this->browser->getDesiredCapabilities();
-
-		if ( isset($travis_job_number) ) {
-			$this->assertArrayHasKey('tunnel-identifier', $desired_capabilities);
-			$this->assertEquals($travis_job_number, $desired_capabilities['tunnel-identifier']);
-		}
-		else {
-			$this->assertArrayNotHasKey('tunnel-identifier', $desired_capabilities);
-		}
-	}
-
-	/**
-	 * Provides Travis job numbers.
-	 *
-	 * @return array
-	 */
-	public function tunnelIdentifierDataProvider()
-	{
-		return array(
-			array('AAA'),
-			array(null),
-		);
 	}
 
 	/**

--- a/tests/aik099/PHPUnit/Fixture/SetupEventFixture.php
+++ b/tests/aik099/PHPUnit/Fixture/SetupEventFixture.php
@@ -62,8 +62,9 @@ class SetupEventFixture extends BrowserTestCase
 		// For SauceLabsBrowserConfiguration::onTestEnded.
 		$session->shouldReceive('getDriver')->once()->andReturn($driver);
 
-		// For IsolatedSessionStrategy::onTestEnd (twice because we have 2 strategies listening for test end).
-		$session->shouldReceive('stop')->twice();
+		// For IsolatedSessionStrategy::onTestEnd (twice per each browser because
+		// we have 2 strategies listening for test end).
+		$session->shouldReceive('stop')->times(4);
 		$session->shouldReceive('isStarted')->andReturn(true);
 
 		$this->_setSession($session);


### PR DESCRIPTION
Also:
- added "IAPIClient::getInfo" method for getting session-related data from SauceLabs/BrowserStack
- updated DocBlock of "IAPIClient::updateStatus" to indicate that in fact array is being returned instead of boolean
- the "ApiBrowserConfiguration::getAPIClient" method was made public to allow users interacting with SauceLabs/BrowserStack
- update default Windows version to "Windows 7" in BrowserStack browser configuration

Closes #8