### PR TITLE
Don't create tunnel for SauceLabs on Travis CI by default

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,9 +32,6 @@ env:
         - secure: Tsh/Vvb9auy672eRf0xbN8fKDr8OYzjRkZDHiaYc5yH49UkoromwPaC74mJtM5KxFOYalrC+GzwOSuvzT8RYO/XwTuk6IGw9P/0v0qMCaSLkjaRzerwVH1L3RPgDokqDnCHAgSzkAlg8d5o0MWBlbxaYiaKL4LmEKGwxQjrW590=
         - secure: HQQ1FY27tpn0Idy+NDYXdbnMjHKIOsZoE59qYfs18euS0zM559gcuMk4OQ/J2lcDFmdb6vjSFlznwH+6iVyoLuC5WAP3JGQ3UXSJ+7huRV/eDI6WepmEymjEOSWvTT+RYpmQu1lQWC2Y3zBCVbVT7sbVsqXvmuR2daBL11dpU+g=
 
-addons:
-    sauce_connect: true
-
 install:
     - composer require satooshi/php-coveralls:dev-master --dev
 

--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -50,6 +50,20 @@ tests were running locally.
    :linenos:
    :emphasize-lines: 11-13,19-21
 
+Continuous Integration
+^^^^^^^^^^^^^^^^^^^^^^
+When website under test isn't publicly accessible, then:
+
+#. secure tunnel needs to be created from website under test to server, that runs the tests
+#. created tunnel identifier needs to specified in the ``PHPUNIT_MINK_TUNNEL_ID`` environment variable
+
+.. note:: Before v2.1.0 the environment variable was called ``TRAVIS_JOB_NUMBER``.
+
+How to Create a Tunnel
+----------------------
+* SauceLabs: https://docs.saucelabs.com/reference/sauce-connect/
+* BrowserStack: http://www.browserstack.com/automate/php#setting-local-tunnel
+
 .. _`Mink`: https://github.com/Behat/Mink
 .. _`Sauce Labs`: https://saucelabs.com/
 .. _`BrowserStack`: http://www.browserstack.com/

--- a/library/aik099/PHPUnit/BrowserConfiguration/BrowserStackBrowserConfiguration.php
+++ b/library/aik099/PHPUnit/BrowserConfiguration/BrowserStackBrowserConfiguration.php
@@ -54,9 +54,9 @@ class BrowserStackBrowserConfiguration extends ApiBrowserConfiguration
 
 		$desired_capabilities = $this->getDesiredCapabilities();
 
-		if ( getenv('TRAVIS_JOB_NUMBER') ) {
+		if ( getenv('PHPUNIT_MINK_TUNNEL_ID') ) {
 			$desired_capabilities['browserstack.local'] = 'true';
-			$desired_capabilities['browserstack.localIdentifier'] = getenv('TRAVIS_JOB_NUMBER');
+			$desired_capabilities['browserstack.localIdentifier'] = getenv('PHPUNIT_MINK_TUNNEL_ID');
 		}
 
 		$this->setDesiredCapabilities($desired_capabilities);

--- a/library/aik099/PHPUnit/BrowserConfiguration/SauceLabsBrowserConfiguration.php
+++ b/library/aik099/PHPUnit/BrowserConfiguration/SauceLabsBrowserConfiguration.php
@@ -54,8 +54,8 @@ class SauceLabsBrowserConfiguration extends ApiBrowserConfiguration
 
 		$desired_capabilities = $this->getDesiredCapabilities();
 
-		if ( getenv('TRAVIS_JOB_NUMBER') ) {
-			$desired_capabilities['tunnel-identifier'] = getenv('TRAVIS_JOB_NUMBER');
+		if ( getenv('PHPUNIT_MINK_TUNNEL_ID') ) {
+			$desired_capabilities['tunnel-identifier'] = getenv('PHPUNIT_MINK_TUNNEL_ID');
 		}
 
 		$this->setDesiredCapabilities($desired_capabilities);

--- a/tests/aik099/PHPUnit/BrowserConfiguration/ApiBrowserConfigurationTestCase.php
+++ b/tests/aik099/PHPUnit/BrowserConfiguration/ApiBrowserConfigurationTestCase.php
@@ -381,20 +381,20 @@ abstract class ApiBrowserConfigurationTestCase extends BrowserConfigurationTest
 	/**
 	 * Test description.
 	 *
-	 * @param string|null $travis_job_number Travis Job Number.
+	 * @param string|null $tunnel_id Tunnel ID.
 	 *
 	 * @return void
 	 * @dataProvider tunnelIdentifierDataProvider
 	 */
-	public function testTunnelIdentifier($travis_job_number = null)
+	public function testTunnelIdentifier($tunnel_id = null)
 	{
 		// Reset any global env vars that might be left from previous tests.
 		$hhvm_hack = defined('HHVM_VERSION') ? '=' : '';
 
-		putenv('TRAVIS_JOB_NUMBER' . $hhvm_hack);
+		putenv('PHPUNIT_MINK_TUNNEL_ID' . $hhvm_hack);
 
-		if ( isset($travis_job_number) ) {
-			putenv('TRAVIS_JOB_NUMBER=' . $travis_job_number);
+		if ( isset($tunnel_id) ) {
+			putenv('PHPUNIT_MINK_TUNNEL_ID=' . $tunnel_id);
 		}
 
 		$this->browser->setSessionStrategy(ISessionStrategyFactory::TYPE_ISOLATED);
@@ -412,7 +412,7 @@ abstract class ApiBrowserConfigurationTestCase extends BrowserConfigurationTest
 
 		$desired_capabilities = $this->browser->getDesiredCapabilities();
 
-		if ( isset($travis_job_number) ) {
+		if ( isset($tunnel_id) ) {
 			foreach ( $this->tunnelCapabilities as $name => $value ) {
 				if ( substr($value, 0, 4) === 'env:' ) {
 					$value = getenv(substr($value, 4));

--- a/tests/aik099/PHPUnit/BrowserConfiguration/BrowserStackBrowserConfigurationTest.php
+++ b/tests/aik099/PHPUnit/BrowserConfiguration/BrowserStackBrowserConfigurationTest.php
@@ -29,7 +29,7 @@ class BrowserStackBrowserConfigurationTest extends ApiBrowserConfigurationTestCa
 
 		$this->tunnelCapabilities = array(
 			'browserstack.local' => 'true',
-			'browserstack.localIdentifier' => 'env:TRAVIS_JOB_NUMBER',
+			'browserstack.localIdentifier' => 'env:PHPUNIT_MINK_TUNNEL_ID',
 		);
 
 		parent::setUp();

--- a/tests/aik099/PHPUnit/BrowserConfiguration/SauceLabsBrowserConfigurationTest.php
+++ b/tests/aik099/PHPUnit/BrowserConfiguration/SauceLabsBrowserConfigurationTest.php
@@ -32,7 +32,7 @@ class SauceLabsBrowserConfigurationTest extends ApiBrowserConfigurationTestCase
 		$this->browserConfigurationClass = 'aik099\\PHPUnit\\BrowserConfiguration\\SauceLabsBrowserConfiguration';
 
 		$this->tunnelCapabilities = array(
-			'tunnel-identifier' => 'env:TRAVIS_JOB_NUMBER',
+			'tunnel-identifier' => 'env:PHPUNIT_MINK_TUNNEL_ID',
 		);
 
 		parent::setUp();


### PR DESCRIPTION
Enabling tunnel support automatically, when library is being used on Travis CI is incorrect, because tests using the library might be accessing public only resoures and we don't want to slow down the build by waiting for tunnel to open.

This is exactly the case with library's own tests (it's accessing only http://www.google.com).