### PR TITLE
Don't collect code coverage on HHVM because it doesn't have xdebug

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,9 +39,10 @@ before_script:
     - mkdir -p build/logs
 
 script:
-    - phpunit -v --coverage-clover build/logs/clover.xml
+    - if [ "$TRAVIS_PHP_VERSION" != "hhvm" ]; then phpunit --coverage-clover build/logs/clover.xml; fi;
+    - if [ "$TRAVIS_PHP_VERSION" = "hhvm" ]; then phpunit; fi;
 
 after_script:
-    - php vendor/bin/coveralls -v
-    - wget https://scrutinizer-ci.com/ocular.phar -t 3
-    - php ocular.phar code-coverage:upload --format=php-clover build/logs/clover.xml
+    - if [ "$TRAVIS_PHP_VERSION" != "hhvm" ]; then php vendor/bin/coveralls -v; fi;
+    - if [ "$TRAVIS_PHP_VERSION" != "hhvm" ]; then wget https://scrutinizer-ci.com/ocular.phar -t 3; fi;
+    - if [ "$TRAVIS_PHP_VERSION" != "hhvm" ]; then php ocular.phar code-coverage:upload --format=php-clover build/logs/clover.xml; fi;


### PR DESCRIPTION
Recent update to PHPUnit caused HHVM builds, attempting to collect code coverage fail with following output:

```
atal error: Uncaught exception 'PHP_CodeCoverage_Exception' with message 'This driver requires Xdebug' in /home/travis/build/minkphp/phpunit-mink/vendor/phpunit/php-code-coverage/src/CodeCoverage/Driver/Xdebug.php:25
Stack trace:
#0 /home/travis/build/minkphp/phpunit-mink/vendor/phpunit/php-code-coverage/src/CodeCoverage.php(914): PHP_CodeCoverage_Driver_Xdebug->__construct()
#1 /home/travis/build/minkphp/phpunit-mink/vendor/phpunit/php-code-coverage/src/CodeCoverage.php(99): PHP_CodeCoverage->selectDriver()
#2 /home/travis/build/minkphp/phpunit-mink/vendor/phpunit/phpunit/src/TextUI/TestRunner.php(331): PHP_CodeCoverage->__construct()
#3 phar://phpunit-4.5.0.phar/phpunit/TextUI/Command.php(152): PHPUnit_TextUI_TestRunner->doRun()
#4 phar://phpunit-4.5.0.phar/phpunit/TextUI/Command.php(104): PHPUnit_TextUI_Command->run()
#5 /home/travis/.phpenv/versions/hhvm-3.5.0~precise/bin/phpunit(722): PHPUnit_TextUI_Command::main()
#6 {main}
The command "phpunit -v --coverage-clover build/logs/clover.xml" exited with 255.
```