### PR TITLE
Use BrowserStack instead of SauceLabs for integration tests

### DIFF
--- a/tests/aik099/PHPUnit/Integration/BrowserStackAwareTestCase.php
+++ b/tests/aik099/PHPUnit/Integration/BrowserStackAwareTestCase.php
@@ -13,7 +13,7 @@ namespace tests\aik099\PHPUnit\Integration;
 
 use aik099\PHPUnit\BrowserTestCase;
 
-abstract class SauceLabsAwareTestCase extends BrowserTestCase
+abstract class BrowserStackAwareTestCase extends BrowserTestCase
 {
 
 	/**
@@ -22,7 +22,7 @@ abstract class SauceLabsAwareTestCase extends BrowserTestCase
 	 * @var array
 	 */
 	public static $browsers = array(
-		array('alias' => 'saucelabs'),
+		array('alias' => 'browserstack'),
 	);
 
 	/**
@@ -32,8 +32,8 @@ abstract class SauceLabsAwareTestCase extends BrowserTestCase
 	 */
 	protected function setUp()
 	{
-		if ( !getenv('SAUCE_USERNAME') || !getenv('SAUCE_ACCESS_KEY') ) {
-			$this->markTestSkipped('SauceLabs integration is not configured');
+		if ( !getenv('BS_USERNAME') || !getenv('BS_ACCESS_KEY') ) {
+			$this->markTestSkipped('BrowserStack integration is not configured');
 		}
 
 		parent::setUp();
@@ -61,13 +61,13 @@ abstract class SauceLabsAwareTestCase extends BrowserTestCase
 	public function getBrowserAliases()
 	{
 		return array(
-			'saucelabs' => array(
-				'type' => 'saucelabs',
-				'apiUsername' => getenv('SAUCE_USERNAME'),
-				'apiKey' => getenv('SAUCE_ACCESS_KEY'),
+			'browserstack' => array(
+				'type' => 'browserstack',
+				'api_username' => getenv('BS_USERNAME'),
+				'api_key' => getenv('BS_ACCESS_KEY'),
 
 				'browserName' => 'chrome',
-				'desiredCapabilities' => array('version' => 28),
+				'desiredCapabilities' => array('browser_version' => '38.0', 'project' => 'PHPUnit-Mink'),
 				'baseUrl' => 'http://www.google.com',
 			),
 		);

--- a/tests/aik099/PHPUnit/Integration/BrowserStackAwareTestCase.php
+++ b/tests/aik099/PHPUnit/Integration/BrowserStackAwareTestCase.php
@@ -65,9 +65,13 @@ abstract class BrowserStackAwareTestCase extends BrowserTestCase
 				'type' => 'browserstack',
 				'api_username' => getenv('BS_USERNAME'),
 				'api_key' => getenv('BS_ACCESS_KEY'),
-
-				'browserName' => 'chrome',
-				'desiredCapabilities' => array('browser_version' => '38.0', 'project' => 'PHPUnit-Mink'),
+				'browserName' => 'Firefox',
+				'desiredCapabilities' => array(
+					'browser_version' => '41.0',
+					'os' => 'Windows',
+					'os_version' => '7',
+					'project' => 'PHPUnit-Mink',
+				),
 				'baseUrl' => 'http://www.google.com',
 			),
 		);

--- a/tests/aik099/PHPUnit/Integration/DataProviderTest.php
+++ b/tests/aik099/PHPUnit/Integration/DataProviderTest.php
@@ -11,7 +11,7 @@
 namespace tests\aik099\PHPUnit\Integration;
 
 
-class DataProviderTest extends SauceLabsAwareTestCase
+class DataProviderTest extends BrowserStackAwareTestCase
 {
 
 	public function sampleDataProvider()

--- a/tests/aik099/PHPUnit/Integration/IsolatedSessionStrategyTest.php
+++ b/tests/aik099/PHPUnit/Integration/IsolatedSessionStrategyTest.php
@@ -44,7 +44,7 @@ class IsolatedSessionStrategyTest extends BrowserStackAwareTestCase
 	public function testTwo()
 	{
 		$session = $this->getSession();
-		$url = $session->isStarted() ? $session->getCurrentUrl() : null;
+		$url = $session->isStarted() ? $session->getCurrentUrl() : '';
 
 		$this->assertNotContains('https://www.google.com', $url);
 	}

--- a/tests/aik099/PHPUnit/Integration/IsolatedSessionStrategyTest.php
+++ b/tests/aik099/PHPUnit/Integration/IsolatedSessionStrategyTest.php
@@ -11,7 +11,7 @@
 namespace tests\aik099\PHPUnit\Integration;
 
 
-class IsolatedSessionStrategyTest extends SauceLabsAwareTestCase
+class IsolatedSessionStrategyTest extends BrowserStackAwareTestCase
 {
 
 	/**
@@ -21,7 +21,7 @@ class IsolatedSessionStrategyTest extends SauceLabsAwareTestCase
 	 */
 	public static $browsers = array(
 		array(
-			'alias' => 'saucelabs',
+			'alias' => 'browserstack',
 			'sessionStrategy' => 'isolated',
 		),
 	);

--- a/tests/aik099/PHPUnit/Integration/SharedSessionStrategyTest.php
+++ b/tests/aik099/PHPUnit/Integration/SharedSessionStrategyTest.php
@@ -11,7 +11,7 @@
 namespace tests\aik099\PHPUnit\Integration;
 
 
-class SharedSessionStrategyTest extends SauceLabsAwareTestCase
+class SharedSessionStrategyTest extends BrowserStackAwareTestCase
 {
 
 	/**
@@ -21,7 +21,7 @@ class SharedSessionStrategyTest extends SauceLabsAwareTestCase
 	 */
 	public static $browsers = array(
 		array(
-			'alias' => 'saucelabs',
+			'alias' => 'browserstack',
 			'sessionStrategy' => 'shared',
 		),
 	);


### PR DESCRIPTION
The integration tests using SauceLabs seems to be stuck at some point, when communicating with SauceLabs servers (see https://travis-ci.org/minkphp/minkphp/phpunit-mink/builds/86064193) and are dropped by php-invoker.

Let's try if using BrowserStack instead will solve that problem.