### PR TITLE
Revert "Use BrowserStack instead of SauceLabs for integration tests"

### DIFF
--- a/tests/aik099/PHPUnit/Integration/DataProviderTest.php
+++ b/tests/aik099/PHPUnit/Integration/DataProviderTest.php
@@ -11,7 +11,7 @@
 namespace tests\aik099\PHPUnit\Integration;
 
 
-class DataProviderTest extends BrowserStackAwareTestCase
+class DataProviderTest extends SauceLabsAwareTestCase
 {
 
 	public function sampleDataProvider()

--- a/tests/aik099/PHPUnit/Integration/IsolatedSessionStrategyTest.php
+++ b/tests/aik099/PHPUnit/Integration/IsolatedSessionStrategyTest.php
@@ -11,7 +11,7 @@
 namespace tests\aik099\PHPUnit\Integration;
 
 
-class IsolatedSessionStrategyTest extends BrowserStackAwareTestCase
+class IsolatedSessionStrategyTest extends SauceLabsAwareTestCase
 {
 
 	/**
@@ -21,7 +21,7 @@ class IsolatedSessionStrategyTest extends BrowserStackAwareTestCase
 	 */
 	public static $browsers = array(
 		array(
-			'alias' => 'browserstack',
+			'alias' => 'saucelabs',
 			'sessionStrategy' => 'isolated',
 		),
 	);
@@ -44,7 +44,7 @@ class IsolatedSessionStrategyTest extends BrowserStackAwareTestCase
 	public function testTwo()
 	{
 		$session = $this->getSession();
-		$url = $session->isStarted() ? $session->getCurrentUrl() : '';
+		$url = $session->isStarted() ? $session->getCurrentUrl() : null;
 
 		$this->assertNotContains('https://www.google.com', $url);
 	}

--- a/tests/aik099/PHPUnit/Integration/SauceLabsAwareTestCase.php
+++ b/tests/aik099/PHPUnit/Integration/SauceLabsAwareTestCase.php
@@ -13,7 +13,7 @@ namespace tests\aik099\PHPUnit\Integration;
 
 use aik099\PHPUnit\BrowserTestCase;
 
-abstract class BrowserStackAwareTestCase extends BrowserTestCase
+abstract class SauceLabsAwareTestCase extends BrowserTestCase
 {
 
 	/**
@@ -22,7 +22,7 @@ abstract class BrowserStackAwareTestCase extends BrowserTestCase
 	 * @var array
 	 */
 	public static $browsers = array(
-		array('alias' => 'browserstack'),
+		array('alias' => 'saucelabs'),
 	);
 
 	/**
@@ -32,8 +32,8 @@ abstract class BrowserStackAwareTestCase extends BrowserTestCase
 	 */
 	protected function setUp()
 	{
-		if ( !getenv('BS_USERNAME') || !getenv('BS_ACCESS_KEY') ) {
-			$this->markTestSkipped('BrowserStack integration is not configured');
+		if ( !getenv('SAUCE_USERNAME') || !getenv('SAUCE_ACCESS_KEY') ) {
+			$this->markTestSkipped('SauceLabs integration is not configured');
 		}
 
 		parent::setUp();
@@ -61,17 +61,13 @@ abstract class BrowserStackAwareTestCase extends BrowserTestCase
 	public function getBrowserAliases()
 	{
 		return array(
-			'browserstack' => array(
-				'type' => 'browserstack',
-				'api_username' => getenv('BS_USERNAME'),
-				'api_key' => getenv('BS_ACCESS_KEY'),
-				'browserName' => 'Firefox',
-				'desiredCapabilities' => array(
-					'browser_version' => '41.0',
-					'os' => 'Windows',
-					'os_version' => '7',
-					'project' => 'PHPUnit-Mink',
-				),
+			'saucelabs' => array(
+				'type' => 'saucelabs',
+				'apiUsername' => getenv('SAUCE_USERNAME'),
+				'apiKey' => getenv('SAUCE_ACCESS_KEY'),
+
+				'browserName' => 'chrome',
+				'desiredCapabilities' => array('version' => 28),
 				'baseUrl' => 'http://www.google.com',
 			),
 		);

--- a/tests/aik099/PHPUnit/Integration/SharedSessionStrategyTest.php
+++ b/tests/aik099/PHPUnit/Integration/SharedSessionStrategyTest.php
@@ -11,7 +11,7 @@
 namespace tests\aik099\PHPUnit\Integration;
 
 
-class SharedSessionStrategyTest extends BrowserStackAwareTestCase
+class SharedSessionStrategyTest extends SauceLabsAwareTestCase
 {
 
 	/**
@@ -21,7 +21,7 @@ class SharedSessionStrategyTest extends BrowserStackAwareTestCase
 	 */
 	public static $browsers = array(
 		array(
-			'alias' => 'browserstack',
+			'alias' => 'saucelabs',
 			'sessionStrategy' => 'shared',
 		),
 	);


### PR DESCRIPTION
Reverts minkphp/phpunit-mink#61

This made things even worse. Now none if BrowserStack tests pass due limitations on OpenSource account (no concurrent tests possible, but Travis does them).