### PR TITLE
Don't check how long test runs

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,15 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit backupGlobals="true"
-	backupStaticAttributes="false"
+<phpunit
 	bootstrap="vendor/autoload.php"
 	colors="true"
-	convertErrorsToExceptions="true"
-	convertNoticesToExceptions="true"
-	convertWarningsToExceptions="true"
-	processIsolation="false"
-	stopOnFailure="false"
-	strict="true"
-	verbose="true">
+	verbose="true"
+	beStrictAboutChangesToGlobalState="true"
+	beStrictAboutOutputDuringTests="true">
 
 	<testsuites>
 		<testsuite name="PHPUnit">

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -4,7 +4,8 @@
 	colors="true"
 	verbose="true"
 	beStrictAboutChangesToGlobalState="true"
-	beStrictAboutOutputDuringTests="true">
+	beStrictAboutOutputDuringTests="true"
+	beStrictAboutTestSize="true">
 
 	<testsuites>
 		<testsuite name="PHPUnit">

--- a/tests/aik099/PHPUnit/Integration/IsolatedSessionStrategyTest.php
+++ b/tests/aik099/PHPUnit/Integration/IsolatedSessionStrategyTest.php
@@ -27,7 +27,7 @@ class IsolatedSessionStrategyTest extends SauceLabsAwareTestCase
 	);
 
 	/**
-	 * @medium
+	 * @large
 	 */
 	public function testOne()
 	{
@@ -38,7 +38,7 @@ class IsolatedSessionStrategyTest extends SauceLabsAwareTestCase
 	}
 
 	/**
-	 * @medium
+	 * @large
 	 * @depends testOne
 	 */
 	public function testTwo()

--- a/tests/aik099/PHPUnit/Integration/SharedSessionStrategyTest.php
+++ b/tests/aik099/PHPUnit/Integration/SharedSessionStrategyTest.php
@@ -27,7 +27,7 @@ class SharedSessionStrategyTest extends SauceLabsAwareTestCase
 	);
 
 	/**
-	 * @medium
+	 * @large
 	 */
 	public function testOne()
 	{
@@ -38,7 +38,7 @@ class SharedSessionStrategyTest extends SauceLabsAwareTestCase
 	}
 
 	/**
-	 * @medium
+	 * @large
 	 * @depends testOne
 	 */
 	public function testTwo()


### PR DESCRIPTION
Right now fact, that PHP_Invoker checks how long test runs ends up badly for SauceLabs/BrowserStack tests, because they can't do what they are doing within 1 second.

The more granular settings for PHPUnit strictness are used now.