### PR TITLE
Use stable version of coverage reporting library during the build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ env:
         - secure: HQQ1FY27tpn0Idy+NDYXdbnMjHKIOsZoE59qYfs18euS0zM559gcuMk4OQ/J2lcDFmdb6vjSFlznwH+6iVyoLuC5WAP3JGQ3UXSJ+7huRV/eDI6WepmEymjEOSWvTT+RYpmQu1lQWC2Y3zBCVbVT7sbVsqXvmuR2daBL11dpU+g=
 
 install:
-    - composer require satooshi/php-coveralls:dev-master --dev
+    - composer require satooshi/php-coveralls:^1.0 --dev
 
 before_script:
     - mkdir -p build/logs


### PR DESCRIPTION
Before this PR we're depending on `dev-master` version of coverage reporting library, which ended up in failed build, because library author decided to increase minimal required PHP version from 5.3 to 5.5, which in turn made all PHP 5.4 and below builds fail.

This PR changes dependency to stable version (1.0), where using PHP 5.3 is still a possibility.