### PR TITLE
Fix compatibility with PHPUnit 5+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,8 +43,8 @@ before_script:
     - mkdir -p build/logs
 
 script:
-    - if [ "$TRAVIS_PHP_VERSION" != "hhvm" ]; then phpunit --coverage-clover build/logs/clover.xml; fi;
-    - if [ "$TRAVIS_PHP_VERSION" = "hhvm" ]; then phpunit; fi;
+    - if [ "$TRAVIS_PHP_VERSION" != "hhvm" ]; then vendor/bin/phpunit --coverage-clover build/logs/clover.xml; fi;
+    - if [ "$TRAVIS_PHP_VERSION" = "hhvm" ]; then vendor/bin/phpunit; fi;
 
 after_script:
     - if [ "$TRAVIS_PHP_VERSION" != "hhvm" ]; then php vendor/bin/coveralls -v; fi;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ...
 
 ### Fixed
-- Compatibility with PHPUnit 5+ was not given cause of declaration of `aik099\PHPUnit\BrowserTestCase::onNotSuccessfulTest()`
+- Fixed "PHP Strict standards" notice when used with PHPUnit 5+.
 
 ## [2.2.0] - 2016-06-26
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ...
 
 ### Fixed
-...
+- Compatibility with PHPUnit 5+ was not given cause of declaration of `aik099\PHPUnit\BrowserTestCase::onNotSuccessfulTest()`
 
 ## [2.2.0] - 2016-06-26
 ### Added

--- a/library/aik099/PHPUnit/AbstractPHPUnitCompatibilityTestCase.php
+++ b/library/aik099/PHPUnit/AbstractPHPUnitCompatibilityTestCase.php
@@ -40,7 +40,7 @@ if ( version_compare(\PHPUnit_Runner_Version::id(), '5.0.0', '>=') ) {
 		/**
 		 * This method is called when a test method did not execute successfully.
 		 *
-		 * @param \Exception $e
+		 * @param \Exception $e Exception.
 		 *
 		 * @return void
 		 */
@@ -74,7 +74,7 @@ else {
 		/**
 		 * This method is called when a test method did not execute successfully.
 		 *
-		 * @param \Exception $e
+		 * @param \Exception $e Exception.
 		 *
 		 * @return void
 		 */

--- a/library/aik099/PHPUnit/AbstractPHPUnitCompatibilityTestCase.php
+++ b/library/aik099/PHPUnit/AbstractPHPUnitCompatibilityTestCase.php
@@ -20,7 +20,7 @@ if ( version_compare(\PHPUnit_Runner_Version::id(), '5.0.0', '>=') ) {
 	 *
 	 * @internal
 	 */
-	abstract class PHPUnitCompatibilityTestCase extends \PHPUnit_Framework_TestCase
+	abstract class AbstractPHPUnitCompatibilityTestCase extends \PHPUnit_Framework_TestCase
 	{
 
 		/**
@@ -47,7 +47,7 @@ else {
 	 *
 	 * @internal
 	 */
-	abstract class PHPUnitCompatibilityTestCase extends \PHPUnit_Framework_TestCase
+	abstract class AbstractPHPUnitCompatibilityTestCase extends \PHPUnit_Framework_TestCase
 	{
 
 		/**

--- a/library/aik099/PHPUnit/AbstractPHPUnitCompatibilityTestCase.php
+++ b/library/aik099/PHPUnit/AbstractPHPUnitCompatibilityTestCase.php
@@ -37,7 +37,14 @@ if ( version_compare(\PHPUnit_Runner_Version::id(), '5.0.0', '>=') ) {
 			parent::onNotSuccessfulTest($e);
 		}
 
-		abstract protected function onNotSuccessfulTestCompatibilized($e);
+		/**
+		 * This method is called when a test method did not execute successfully.
+		 *
+		 * @param \Exception $e
+		 *
+		 * @return void
+		 */
+		abstract protected function onNotSuccessfulTestCompatibilized(\Exception $e);
 
 	}
 }
@@ -64,7 +71,14 @@ else {
 			parent::onNotSuccessfulTest($e);
 		}
 
-		abstract protected function onNotSuccessfulTestCompatibilized($e);
+		/**
+		 * This method is called when a test method did not execute successfully.
+		 *
+		 * @param \Exception $e
+		 *
+		 * @return void
+		 */
+		abstract protected function onNotSuccessfulTestCompatibilized(\Exception $e);
 
 	}
 }

--- a/library/aik099/PHPUnit/BrowserTestCase.php
+++ b/library/aik099/PHPUnit/BrowserTestCase.php
@@ -419,7 +419,7 @@ abstract class BrowserTestCase extends AbstractPHPUnitCompatibilityTestCase impl
 	 *
 	 * @return void
 	 */
-	protected function onNotSuccessfulTestCompatibilized($e)
+	protected function onNotSuccessfulTestCompatibilized(\Exception $e)
 	{
 		$this->_eventDispatcher->dispatch(
 			self::TEST_FAILED_EVENT,

--- a/library/aik099/PHPUnit/BrowserTestCase.php
+++ b/library/aik099/PHPUnit/BrowserTestCase.php
@@ -30,7 +30,7 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
  *
  * @method \Mockery\Expectation shouldReceive(string $name)
  */
-abstract class BrowserTestCase extends PHPUnitCompatibilityTestCase implements IEventDispatcherAware
+abstract class BrowserTestCase extends AbstractPHPUnitCompatibilityTestCase implements IEventDispatcherAware
 {
 
 	const TEST_ENDED_EVENT = 'test.ended';

--- a/library/aik099/PHPUnit/BrowserTestCase.php
+++ b/library/aik099/PHPUnit/BrowserTestCase.php
@@ -30,7 +30,7 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
  *
  * @method \Mockery\Expectation shouldReceive(string $name)
  */
-abstract class BrowserTestCase extends \PHPUnit_Framework_TestCase implements IEventDispatcherAware
+abstract class BrowserTestCase extends PHPUnitCompatibilityTestCase implements IEventDispatcherAware
 {
 
 	const TEST_ENDED_EVENT = 'test.ended';
@@ -419,14 +419,12 @@ abstract class BrowserTestCase extends \PHPUnit_Framework_TestCase implements IE
 	 *
 	 * @return void
 	 */
-	protected function onNotSuccessfulTest(\Exception $e)
+	protected function onNotSuccessfulTestCompatibilized($e)
 	{
 		$this->_eventDispatcher->dispatch(
 			self::TEST_FAILED_EVENT,
 			new TestFailedEvent($e, $this, $this->_session)
 		);
-
-		parent::onNotSuccessfulTest($e);
 	}
 
 	/**

--- a/library/aik099/PHPUnit/PHPUnitCompatibilityTestCase.php
+++ b/library/aik099/PHPUnit/PHPUnitCompatibilityTestCase.php
@@ -10,55 +10,61 @@
 
 namespace aik099\PHPUnit;
 
-if (version_compare(\PHPUnit_Runner_Version::id(), '5.0.0', '>=')) {
-    /**
-     * Implementation for PHPUnit 5+
-     *
-     * This code should be moved back to aik099\PHPUnit\BrowserTestCase when dropping support for
-     * PHP 5.5 and older, as PHPUnit 4 won't be needed anymore.
-     *
-     * @internal
-     */
-    abstract class PHPUnitCompatibilityTestCase extends \PHPUnit_Framework_TestCase
-    {
-        /**
-         * This method is called when a test method did not execute successfully.
-         *
-         * @param \Exception $e Exception.
-         *
-         * @return void
-         */
-        protected function onNotSuccessfulTest($e)
-        {
-            $this->onNotSuccessfulTestCompatibilized($e);
 
-            parent::onNotSuccessfulTest($e);
-        }
+if ( version_compare(\PHPUnit_Runner_Version::id(), '5.0.0', '>=') ) {
+	/**
+	 * Implementation for PHPUnit 5+
+	 *
+	 * This code should be moved back to aik099\PHPUnit\BrowserTestCase when dropping support for
+	 * PHP 5.5 and older, as PHPUnit 4 won't be needed anymore.
+	 *
+	 * @internal
+	 */
+	abstract class PHPUnitCompatibilityTestCase extends \PHPUnit_Framework_TestCase
+	{
 
-        abstract protected function onNotSuccessfulTestCompatibilized($e);
-    }
-} else {
-    /**
-     * Implementation for PHPUnit 4
-     *
-     * @internal
-     */
-    abstract class PHPUnitCompatibilityTestCase extends \PHPUnit_Framework_TestCase
-    {
-        /**
-         * This method is called when a test method did not execute successfully.
-         *
-         * @param \Exception $e Exception.
-         *
-         * @return void
-         */
-        protected function onNotSuccessfulTest(\Exception $e)
-        {
-            $this->onNotSuccessfulTestCompatibilized($e);
+		/**
+		 * This method is called when a test method did not execute successfully.
+		 *
+		 * @param \Exception $e Exception.
+		 *
+		 * @return void
+		 */
+		protected function onNotSuccessfulTest($e)
+		{
+			$this->onNotSuccessfulTestCompatibilized($e);
 
-            parent::onNotSuccessfulTest($e);
-        }
+			parent::onNotSuccessfulTest($e);
+		}
 
-        abstract protected function onNotSuccessfulTestCompatibilized($e);
-    }
+		abstract protected function onNotSuccessfulTestCompatibilized($e);
+
+	}
+}
+else {
+	/**
+	 * Implementation for PHPUnit 4
+	 *
+	 * @internal
+	 */
+	abstract class PHPUnitCompatibilityTestCase extends \PHPUnit_Framework_TestCase
+	{
+
+		/**
+		 * This method is called when a test method did not execute successfully.
+		 *
+		 * @param \Exception $e Exception.
+		 *
+		 * @return void
+		 */
+		protected function onNotSuccessfulTest(\Exception $e)
+		{
+			$this->onNotSuccessfulTestCompatibilized($e);
+
+			parent::onNotSuccessfulTest($e);
+		}
+
+		abstract protected function onNotSuccessfulTestCompatibilized($e);
+
+	}
 }

--- a/library/aik099/PHPUnit/PHPUnitCompatibilityTestCase.php
+++ b/library/aik099/PHPUnit/PHPUnitCompatibilityTestCase.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * This file is part of the phpunit-mink library.
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @copyright Alexander Obuhovich <aik.bold@gmail.com>
+ * @link      https://github.com/aik099/phpunit-mink
+ */
+
+namespace aik099\PHPUnit;
+
+if (version_compare(\PHPUnit_Runner_Version::id(), '5.0.0', '>=')) {
+    /**
+     * Implementation for PHPUnit 5+
+     *
+     * This code should be moved back to aik099\PHPUnit\BrowserTestCase when dropping support for
+     * PHP 5.5 and older, as PHPUnit 4 won't be needed anymore.
+     *
+     * @internal
+     */
+    abstract class PHPUnitCompatibilityTestCase extends \PHPUnit_Framework_TestCase
+    {
+        /**
+         * This method is called when a test method did not execute successfully.
+         *
+         * @param \Exception $e Exception.
+         *
+         * @return void
+         */
+        protected function onNotSuccessfulTest($e)
+        {
+            $this->onNotSuccessfulTestCompatibilized($e);
+
+            parent::onNotSuccessfulTest($e);
+        }
+
+        abstract protected function onNotSuccessfulTestCompatibilized($e);
+    }
+} else {
+    /**
+     * Implementation for PHPUnit 4
+     *
+     * @internal
+     */
+    abstract class PHPUnitCompatibilityTestCase extends \PHPUnit_Framework_TestCase
+    {
+        /**
+         * This method is called when a test method did not execute successfully.
+         *
+         * @param \Exception $e Exception.
+         *
+         * @return void
+         */
+        protected function onNotSuccessfulTest(\Exception $e)
+        {
+            $this->onNotSuccessfulTestCompatibilized($e);
+
+            parent::onNotSuccessfulTest($e);
+        }
+
+        abstract protected function onNotSuccessfulTestCompatibilized($e);
+    }
+}


### PR DESCRIPTION
This should solve issue #77 

* apply fix based on solution in minkphp/Mink#687
* use locally installed phpunit version in travis ci instead of phpunit version provided by travis 
* not quite sure about naming of new abstract class ```AbstractPHPUnitCompatibilityTestCase``` and method ```onNotSuccessfulTestCompatibilized```

If this gets merged #87 can be closed as well cause it references same issue.