### PR TITLE
Fix failing HHVM builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ php:
     - 5.5
     - 5.6
     - 7.0
-    - hhvm
 
 matrix:
     include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,8 @@ matrix:
           before_script: []
           script: sphinx-build -nW -b html -d docs/build/doctrees docs docs/build/html
           after_script: []
+        - php: hhvm
+          dist: trusty
     allow_failures:
         - php: 7.0
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,8 +44,8 @@ before_script:
     - mkdir -p build/logs
 
 script:
-    - if [ "$TRAVIS_PHP_VERSION" != "hhvm" ]; then phpunit --coverage-clover build/logs/clover.xml; fi;
-    - if [ "$TRAVIS_PHP_VERSION" = "hhvm" ]; then phpunit; fi;
+    - if [ "$TRAVIS_PHP_VERSION" != "hhvm" ]; then vendor/bin/phpunit --coverage-clover build/logs/clover.xml; fi;
+    - if [ "$TRAVIS_PHP_VERSION" = "hhvm" ]; then vendor/bin/phpunit; fi;
 
 after_script:
     - if [ "$TRAVIS_PHP_VERSION" != "hhvm" ]; then php vendor/bin/coveralls -v; fi;


### PR DESCRIPTION
Builds on travis ci raises error with:
```
HHVM is no longer supported on Ubuntu Precise. Please consider using Trusty with `dist: trusty`.
```

For discussion about this PR see https://github.com/minkphp/phpunit-mink/pull/89#issuecomment-316062732
Solution is based on PR console-helpers/svn-buddy#112.