### PR TITLE
use PHPUnit for used PHP version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,7 @@ env:
         - secure: HQQ1FY27tpn0Idy+NDYXdbnMjHKIOsZoE59qYfs18euS0zM559gcuMk4OQ/J2lcDFmdb6vjSFlznwH+6iVyoLuC5WAP3JGQ3UXSJ+7huRV/eDI6WepmEymjEOSWvTT+RYpmQu1lQWC2Y3zBCVbVT7sbVsqXvmuR2daBL11dpU+g=
 
 install:
+    - composer update phpunit/phpunit --with-dependencies
     - composer require satooshi/php-coveralls:^1.0 --dev
 
 before_script:

--- a/tests/PimpleCopy/Pimple/PimpleTest.php
+++ b/tests/PimpleCopy/Pimple/PimpleTest.php
@@ -189,7 +189,13 @@ class PimpleTest extends \PHPUnit_Framework_TestCase
 	public function testFluentRegister()
 	{
 		$pimple = new Container();
-		$this->assertSame($pimple, $pimple->register($this->getMock('PimpleCopy\Pimple\ServiceProviderInterface')));
+		if ( version_compare(\PHPUnit_Runner_Version::id(), '5.4.0', '>=') ) {
+			$serviceProviderMock = $this->createMock('PimpleCopy\Pimple\ServiceProviderInterface');
+		} else {
+			$serviceProviderMock = $this->getMock('PimpleCopy\Pimple\ServiceProviderInterface');
+		}
+
+		$this->assertSame($pimple, $pimple->register($serviceProviderMock));
 	}
 
 	/**

--- a/tests/PimpleCopy/Pimple/PimpleTest.php
+++ b/tests/PimpleCopy/Pimple/PimpleTest.php
@@ -26,6 +26,7 @@
 
 namespace tests\PimpleCopy\Pimple;
 
+use Mockery as m;
 use PimpleCopy\Pimple\Container;
 
 /**
@@ -189,11 +190,8 @@ class PimpleTest extends \PHPUnit_Framework_TestCase
 	public function testFluentRegister()
 	{
 		$pimple = new Container();
-		if ( version_compare(\PHPUnit_Runner_Version::id(), '5.4.0', '>=') ) {
-			$serviceProviderMock = $this->createMock('PimpleCopy\Pimple\ServiceProviderInterface');
-		} else {
-			$serviceProviderMock = $this->getMock('PimpleCopy\Pimple\ServiceProviderInterface');
-		}
+		$serviceProviderMock = m::mock('PimpleCopy\Pimple\ServiceProviderInterface');
+		$serviceProviderMock->shouldReceive('register');
 
 		$this->assertSame($pimple, $pimple->register($serviceProviderMock));
 	}

--- a/tests/aik099/PHPUnit/Integration/SuiteBuildingTest.php
+++ b/tests/aik099/PHPUnit/Integration/SuiteBuildingTest.php
@@ -110,6 +110,10 @@ class SuiteBuildingTest extends \PHPUnit_Framework_TestCase
 			$suite->shouldReceive('count')->once()->andReturn(1);
 		}
 
+		if ( version_compare(\PHPUnit_Runner_Version::id(), '5.0.0', '>=') ) {
+			$suite->shouldReceive('setBeStrictAboutChangesToGlobalState');
+		}
+
 		return $suite;
 	}
 

--- a/tests/aik099/PHPUnit/Integration/SuiteBuildingTest.php
+++ b/tests/aik099/PHPUnit/Integration/SuiteBuildingTest.php
@@ -111,7 +111,7 @@ class SuiteBuildingTest extends \PHPUnit_Framework_TestCase
 		}
 
 		if ( version_compare(\PHPUnit_Runner_Version::id(), '5.0.0', '>=') ) {
-			$suite->shouldReceive('setBeStrictAboutChangesToGlobalState');
+			$suite->shouldReceive('setbeStrictAboutChangesToGlobalState');
 		}
 
 		return $suite;


### PR DESCRIPTION
- this is first PR for #93 (PHPUnit 6 compatiblity)
- composer update phpunit/phpunit --with-dependencies will result in
following version test matrix

 PHP | PHPUNIT
------- | -------------
5.3|4.8
5.4|4.8
5.5|4.8
5.6|5.7
7.0|6.2*
7.1*|6.2*

*not yet implemented/supported