### PR TITLE
Bump PHPUnit version to 4.8.35+ or 5.4.3+ and use phpunit namespaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 - Bumped minimum PHPUnit version to 4.8.35 or 5.4.3.
-- Use namespace classes of PHPUnit.
+- Use namespaced class versions of PHPUnit.
 
 ### Fixed
 - Fixed "PHP Strict standards" notice when used with PHPUnit 5+.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 - Bumped PHPUnit version to 4.8.35+ or 5.4.3+
+- use namespace classes of PHPUnit
 
 ### Fixed
 - Fixed "PHP Strict standards" notice when used with PHPUnit 5+.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ...
 
 ### Changed
-- Bumped PHPUnit version to 4.8.35+ or 5.4.3+
-- use namespace classes of PHPUnit
+- Bumped minimum PHPUnit version to 4.8.35 or 5.4.3.
+- Use namespace classes of PHPUnit.
 
 ### Fixed
 - Fixed "PHP Strict standards" notice when used with PHPUnit 5+.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ...
 
 ### Changed
-...
+- Bumped PHPUnit version to 4.8.35+ or 5.4.3+
 
 ### Fixed
 - Fixed "PHP Strict standards" notice when used with PHPUnit 5+.

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
 		"behat/mink": "~1.6@dev",
 		"behat/mink-selenium2-driver": "~1.2",
 		"symfony/event-dispatcher": "~2.4|~3.0",
-		"phpunit/phpunit": ">=4.8.35|>=5.4.3"
+		"phpunit/phpunit": ">=4.8.35 <5|>=5.4.3 <6"
 	},
 
 	"require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
 		"behat/mink": "~1.6@dev",
 		"behat/mink-selenium2-driver": "~1.2",
 		"symfony/event-dispatcher": "~2.4|~3.0",
-		"phpunit/phpunit": "~4|~5"
+		"phpunit/phpunit": ">=4.8.35|>=5.4.3"
 	},
 
 	"require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "02a5f1a949dca1b8eaa47bc744d39b21",
+    "content-hash": "055c2e3529a98aa760527bd28585da55",
     "packages": [
         {
             "name": "behat/mink",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "911498094053187c90eedcf84edceaf7",
-    "content-hash": "657e476ce9cc45689f057e102efebca8",
+    "content-hash": "02a5f1a949dca1b8eaa47bc744d39b21",
     "packages": [
         {
             "name": "behat/mink",
@@ -124,7 +123,7 @@
                 "testing",
                 "webdriver"
             ],
-            "time": "2016-03-05 09:10:18"
+            "time": "2016-03-05T09:10:18+00:00"
         },
         {
             "name": "doctrine/instantiator",
@@ -178,7 +177,7 @@
                 "constructor",
                 "instantiate"
             ],
-            "time": "2015-06-14 21:17:01"
+            "time": "2015-06-14T21:17:01+00:00"
         },
         {
             "name": "instaclick/php-webdriver",
@@ -236,20 +235,20 @@
                 "webdriver",
                 "webtest"
             ],
-            "time": "2015-06-15 20:19:33"
+            "time": "2015-06-15T20:19:33+00:00"
         },
         {
             "name": "phpdocumentor/reflection-docblock",
-            "version": "2.0.4",
+            "version": "2.0.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
-                "reference": "d68dbdc53dc358a816f00b300704702b2eaff7b8"
+                "reference": "e6a969a640b00d8daa3c66518b0405fb41ae0c4b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/d68dbdc53dc358a816f00b300704702b2eaff7b8",
-                "reference": "d68dbdc53dc358a816f00b300704702b2eaff7b8",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/e6a969a640b00d8daa3c66518b0405fb41ae0c4b",
+                "reference": "e6a969a640b00d8daa3c66518b0405fb41ae0c4b",
                 "shasum": ""
             },
             "require": {
@@ -285,36 +284,37 @@
                     "email": "mike.vanriel@naenius.com"
                 }
             ],
-            "time": "2015-02-03 12:10:50"
+            "time": "2016-01-25T08:17:30+00:00"
         },
         {
             "name": "phpspec/prophecy",
-            "version": "v1.6.0",
+            "version": "v1.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "3c91bdf81797d725b14cb62906f9a4ce44235972"
+                "reference": "93d39f1f7f9326d746203c7c056f300f7f126073"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/3c91bdf81797d725b14cb62906f9a4ce44235972",
-                "reference": "3c91bdf81797d725b14cb62906f9a4ce44235972",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/93d39f1f7f9326d746203c7c056f300f7f126073",
+                "reference": "93d39f1f7f9326d746203c7c056f300f7f126073",
                 "shasum": ""
             },
             "require": {
                 "doctrine/instantiator": "^1.0.2",
                 "php": "^5.3|^7.0",
-                "phpdocumentor/reflection-docblock": "~2.0",
-                "sebastian/comparator": "~1.1",
-                "sebastian/recursion-context": "~1.0"
+                "phpdocumentor/reflection-docblock": "^2.0|^3.0.2",
+                "sebastian/comparator": "^1.1|^2.0",
+                "sebastian/recursion-context": "^1.0|^2.0|^3.0"
             },
             "require-dev": {
-                "phpspec/phpspec": "~2.0"
+                "phpspec/phpspec": "^2.5|^3.2",
+                "phpunit/phpunit": "^4.8 || ^5.6.5"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.5.x-dev"
+                    "dev-master": "1.6.x-dev"
                 }
             },
             "autoload": {
@@ -347,7 +347,7 @@
                 "spy",
                 "stub"
             ],
-            "time": "2016-02-15 07:46:21"
+            "time": "2017-03-02T20:05:34+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -409,20 +409,20 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2015-10-06 15:47:00"
+            "time": "2015-10-06T15:47:00+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
-            "version": "1.4.1",
+            "version": "1.4.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
-                "reference": "6150bf2c35d3fc379e50c7602b75caceaa39dbf0"
+                "reference": "3cc8f69b3028d0f96a9078e6295d86e9bf019be5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/6150bf2c35d3fc379e50c7602b75caceaa39dbf0",
-                "reference": "6150bf2c35d3fc379e50c7602b75caceaa39dbf0",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/3cc8f69b3028d0f96a9078e6295d86e9bf019be5",
+                "reference": "3cc8f69b3028d0f96a9078e6295d86e9bf019be5",
                 "shasum": ""
             },
             "require": {
@@ -456,7 +456,7 @@
                 "filesystem",
                 "iterator"
             ],
-            "time": "2015-06-21 13:08:43"
+            "time": "2016-10-03T07:40:28+00:00"
         },
         {
             "name": "phpunit/php-text-template",
@@ -497,29 +497,34 @@
             "keywords": [
                 "template"
             ],
-            "time": "2015-06-21 13:50:34"
+            "time": "2015-06-21T13:50:34+00:00"
         },
         {
             "name": "phpunit/php-timer",
-            "version": "1.0.8",
+            "version": "1.0.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-timer.git",
-                "reference": "38e9124049cf1a164f1e4537caf19c99bf1eb260"
+                "reference": "3dcf38ca72b158baf0bc245e9184d3fdffa9c46f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/38e9124049cf1a164f1e4537caf19c99bf1eb260",
-                "reference": "38e9124049cf1a164f1e4537caf19c99bf1eb260",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/3dcf38ca72b158baf0bc245e9184d3fdffa9c46f",
+                "reference": "3dcf38ca72b158baf0bc245e9184d3fdffa9c46f",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": "^5.3.3 || ^7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4|~5"
+                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.0"
             },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
             "autoload": {
                 "classmap": [
                     "src/"
@@ -541,20 +546,20 @@
             "keywords": [
                 "timer"
             ],
-            "time": "2016-05-12 18:03:57"
+            "time": "2017-02-26T11:10:40+00:00"
         },
         {
             "name": "phpunit/php-token-stream",
-            "version": "1.4.8",
+            "version": "1.4.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-token-stream.git",
-                "reference": "3144ae21711fb6cac0b1ab4cbe63b75ce3d4e8da"
+                "reference": "e03f8f67534427a787e21a385a67ec3ca6978ea7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/3144ae21711fb6cac0b1ab4cbe63b75ce3d4e8da",
-                "reference": "3144ae21711fb6cac0b1ab4cbe63b75ce3d4e8da",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/e03f8f67534427a787e21a385a67ec3ca6978ea7",
+                "reference": "e03f8f67534427a787e21a385a67ec3ca6978ea7",
                 "shasum": ""
             },
             "require": {
@@ -590,20 +595,20 @@
             "keywords": [
                 "tokenizer"
             ],
-            "time": "2015-09-15 10:49:45"
+            "time": "2017-02-27T10:12:30+00:00"
         },
         {
             "name": "phpunit/phpunit",
-            "version": "4.8.26",
+            "version": "4.8.36",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "fc1d8cd5b5de11625979125c5639347896ac2c74"
+                "reference": "46023de9a91eec7dfb06cc56cb4e260017298517"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/fc1d8cd5b5de11625979125c5639347896ac2c74",
-                "reference": "fc1d8cd5b5de11625979125c5639347896ac2c74",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/46023de9a91eec7dfb06cc56cb4e260017298517",
+                "reference": "46023de9a91eec7dfb06cc56cb4e260017298517",
                 "shasum": ""
             },
             "require": {
@@ -619,7 +624,7 @@
                 "phpunit/php-text-template": "~1.2",
                 "phpunit/php-timer": "^1.0.6",
                 "phpunit/phpunit-mock-objects": "~2.3",
-                "sebastian/comparator": "~1.1",
+                "sebastian/comparator": "~1.2.2",
                 "sebastian/diff": "~1.2",
                 "sebastian/environment": "~1.3",
                 "sebastian/exporter": "~1.2",
@@ -662,7 +667,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2016-05-17 03:09:28"
+            "time": "2017-06-21T08:07:12+00:00"
         },
         {
             "name": "phpunit/phpunit-mock-objects",
@@ -718,26 +723,26 @@
                 "mock",
                 "xunit"
             ],
-            "time": "2015-10-02 06:51:40"
+            "time": "2015-10-02T06:51:40+00:00"
         },
         {
             "name": "sebastian/comparator",
-            "version": "1.2.0",
+            "version": "1.2.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "937efb279bd37a375bcadf584dec0726f84dbf22"
+                "reference": "2b7424b55f5047b47ac6e5ccb20b2aea4011d9be"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/937efb279bd37a375bcadf584dec0726f84dbf22",
-                "reference": "937efb279bd37a375bcadf584dec0726f84dbf22",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/2b7424b55f5047b47ac6e5ccb20b2aea4011d9be",
+                "reference": "2b7424b55f5047b47ac6e5ccb20b2aea4011d9be",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.3",
                 "sebastian/diff": "~1.2",
-                "sebastian/exporter": "~1.2"
+                "sebastian/exporter": "~1.2 || ~2.0"
             },
             "require-dev": {
                 "phpunit/phpunit": "~4.4"
@@ -782,27 +787,27 @@
                 "compare",
                 "equality"
             ],
-            "time": "2015-07-26 15:48:44"
+            "time": "2017-01-29T09:50:25+00:00"
         },
         {
             "name": "sebastian/diff",
-            "version": "1.4.1",
+            "version": "1.4.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "13edfd8706462032c2f52b4b862974dd46b71c9e"
+                "reference": "7f066a26a962dbe58ddea9f72a4e82874a3975a4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/13edfd8706462032c2f52b4b862974dd46b71c9e",
-                "reference": "13edfd8706462032c2f52b4b862974dd46b71c9e",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/7f066a26a962dbe58ddea9f72a4e82874a3975a4",
+                "reference": "7f066a26a962dbe58ddea9f72a4e82874a3975a4",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": "^5.3.3 || ^7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.8"
+                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.0"
             },
             "type": "library",
             "extra": {
@@ -834,27 +839,27 @@
             "keywords": [
                 "diff"
             ],
-            "time": "2015-12-08 07:14:41"
+            "time": "2017-05-22T07:24:03+00:00"
         },
         {
             "name": "sebastian/environment",
-            "version": "1.3.7",
+            "version": "1.3.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "4e8f0da10ac5802913afc151413bc8c53b6c2716"
+                "reference": "be2c607e43ce4c89ecd60e75c6a85c126e754aea"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/4e8f0da10ac5802913afc151413bc8c53b6c2716",
-                "reference": "4e8f0da10ac5802913afc151413bc8c53b6c2716",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/be2c607e43ce4c89ecd60e75c6a85c126e754aea",
+                "reference": "be2c607e43ce4c89ecd60e75c6a85c126e754aea",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": "^5.3.3 || ^7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.4"
+                "phpunit/phpunit": "^4.8 || ^5.0"
             },
             "type": "library",
             "extra": {
@@ -884,20 +889,20 @@
                 "environment",
                 "hhvm"
             ],
-            "time": "2016-05-17 03:18:57"
+            "time": "2016-08-18T05:49:44+00:00"
         },
         {
             "name": "sebastian/exporter",
-            "version": "1.2.1",
+            "version": "1.2.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "7ae5513327cb536431847bcc0c10edba2701064e"
+                "reference": "42c4c2eec485ee3e159ec9884f95b431287edde4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/7ae5513327cb536431847bcc0c10edba2701064e",
-                "reference": "7ae5513327cb536431847bcc0c10edba2701064e",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/42c4c2eec485ee3e159ec9884f95b431287edde4",
+                "reference": "42c4c2eec485ee3e159ec9884f95b431287edde4",
                 "shasum": ""
             },
             "require": {
@@ -905,12 +910,13 @@
                 "sebastian/recursion-context": "~1.0"
             },
             "require-dev": {
+                "ext-mbstring": "*",
                 "phpunit/phpunit": "~4.4"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.2.x-dev"
+                    "dev-master": "1.3.x-dev"
                 }
             },
             "autoload": {
@@ -950,7 +956,7 @@
                 "export",
                 "exporter"
             ],
-            "time": "2015-06-21 07:55:53"
+            "time": "2016-06-17T09:04:28+00:00"
         },
         {
             "name": "sebastian/global-state",
@@ -1001,20 +1007,20 @@
             "keywords": [
                 "global state"
             ],
-            "time": "2015-10-12 03:26:01"
+            "time": "2015-10-12T03:26:01+00:00"
         },
         {
             "name": "sebastian/recursion-context",
-            "version": "1.0.2",
+            "version": "1.0.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/recursion-context.git",
-                "reference": "913401df809e99e4f47b27cdd781f4a258d58791"
+                "reference": "b19cc3298482a335a95f3016d2f8a6950f0fbcd7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/913401df809e99e4f47b27cdd781f4a258d58791",
-                "reference": "913401df809e99e4f47b27cdd781f4a258d58791",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/b19cc3298482a335a95f3016d2f8a6950f0fbcd7",
+                "reference": "b19cc3298482a335a95f3016d2f8a6950f0fbcd7",
                 "shasum": ""
             },
             "require": {
@@ -1054,7 +1060,7 @@
             ],
             "description": "Provides functionality to recursively process PHP variables",
             "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
-            "time": "2015-11-11 19:50:13"
+            "time": "2016-10-03T07:41:43+00:00"
         },
         {
             "name": "sebastian/version",
@@ -1089,7 +1095,7 @@
             ],
             "description": "Library that helps with managing the version number of Git-hosted PHP projects",
             "homepage": "https://github.com/sebastianbergmann/version",
-            "time": "2015-06-21 13:59:46"
+            "time": "2015-06-21T13:59:46+00:00"
         },
         {
             "name": "symfony/css-selector",
@@ -1142,7 +1148,7 @@
             ],
             "description": "Symfony CssSelector Component",
             "homepage": "https://symfony.com",
-            "time": "2016-03-04 07:54:35"
+            "time": "2016-03-04T07:54:35+00:00"
         },
         {
             "name": "symfony/event-dispatcher",
@@ -1202,20 +1208,20 @@
             ],
             "description": "Symfony EventDispatcher Component",
             "homepage": "https://symfony.com",
-            "time": "2016-05-03 18:59:18"
+            "time": "2016-05-03T18:59:18+00:00"
         },
         {
             "name": "symfony/yaml",
-            "version": "v2.8.6",
+            "version": "v2.8.26",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "e4fbcc65f90909c999ac3b4dfa699ee6563a9940"
+                "reference": "4c29dec8d489c4e37cf87ccd7166cd0b0e6a45c5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/e4fbcc65f90909c999ac3b4dfa699ee6563a9940",
-                "reference": "e4fbcc65f90909c999ac3b4dfa699ee6563a9940",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/4c29dec8d489c4e37cf87ccd7166cd0b0e6a45c5",
+                "reference": "4c29dec8d489c4e37cf87ccd7166cd0b0e6a45c5",
                 "shasum": ""
             },
             "require": {
@@ -1251,7 +1257,7 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
-            "time": "2016-03-29 19:00:15"
+            "time": "2017-06-01T20:52:29+00:00"
         }
     ],
     "packages-dev": [
@@ -1338,19 +1344,19 @@
             "keywords": [
                 "test"
             ],
-            "time": "2015-05-11 14:41:42"
+            "time": "2015-05-11T14:41:42+00:00"
         },
         {
             "name": "mockery/mockery",
             "version": "0.9.4",
             "source": {
                 "type": "git",
-                "url": "https://github.com/padraic/mockery.git",
+                "url": "https://github.com/mockery/mockery.git",
                 "reference": "70bba85e4aabc9449626651f48b9018ede04f86b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/padraic/mockery/zipball/70bba85e4aabc9449626651f48b9018ede04f86b",
+                "url": "https://api.github.com/repos/mockery/mockery/zipball/70bba85e4aabc9449626651f48b9018ede04f86b",
                 "reference": "70bba85e4aabc9449626651f48b9018ede04f86b",
                 "shasum": ""
             },
@@ -1403,7 +1409,7 @@
                 "test double",
                 "testing"
             ],
-            "time": "2015-04-02 19:54:00"
+            "time": "2015-04-02T19:54:00+00:00"
         }
     ],
     "aliases": [],

--- a/library/aik099/PHPUnit/AbstractPHPUnitCompatibilityTestCase.php
+++ b/library/aik099/PHPUnit/AbstractPHPUnitCompatibilityTestCase.php
@@ -11,6 +11,8 @@
 namespace aik099\PHPUnit;
 
 
+use PHPUnit\Framework\TestCase;
+
 if ( version_compare(\PHPUnit_Runner_Version::id(), '5.0.0', '>=') ) {
 	/**
 	 * Implementation for PHPUnit 5+
@@ -20,7 +22,7 @@ if ( version_compare(\PHPUnit_Runner_Version::id(), '5.0.0', '>=') ) {
 	 *
 	 * @internal
 	 */
-	abstract class AbstractPHPUnitCompatibilityTestCase extends \PHPUnit_Framework_TestCase
+	abstract class AbstractPHPUnitCompatibilityTestCase extends TestCase
 	{
 
 		/**
@@ -54,7 +56,7 @@ else {
 	 *
 	 * @internal
 	 */
-	abstract class AbstractPHPUnitCompatibilityTestCase extends \PHPUnit_Framework_TestCase
+	abstract class AbstractPHPUnitCompatibilityTestCase extends TestCase
 	{
 
 		/**

--- a/library/aik099/PHPUnit/TestSuite/AbstractTestSuite.php
+++ b/library/aik099/PHPUnit/TestSuite/AbstractTestSuite.php
@@ -16,7 +16,7 @@ use aik099\PHPUnit\BrowserTestCase;
 use aik099\PHPUnit\IEventDispatcherAware;
 use aik099\PHPUnit\RemoteCoverage\RemoteCoverageHelper;
 use aik099\PHPUnit\Session\SessionStrategyManager;
-use ReflectionClass;
+use PHPUnit\Framework\TestSuite;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 /**
@@ -24,7 +24,7 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
  *
  * @method \Mockery\Expectation shouldReceive(string $name)
  */
-abstract class AbstractTestSuite extends \PHPUnit_Framework_TestSuite implements IEventDispatcherAware
+abstract class AbstractTestSuite extends TestSuite implements IEventDispatcherAware
 {
 
 	/**

--- a/tests/PimpleCopy/Pimple/PimpleServiceProviderInterfaceTest.php
+++ b/tests/PimpleCopy/Pimple/PimpleServiceProviderInterfaceTest.php
@@ -27,12 +27,13 @@
 namespace tests\PimpleCopy\Pimple;
 
 
+use PHPUnit\Framework\TestCase;
 use PimpleCopy\Pimple\Container;
 
 /**
  * @author  Dominik Zogg <dominik.zogg@gmail.com>
  */
-class PimpleServiceProviderInterfaceTest extends \PHPUnit_Framework_TestCase
+class PimpleServiceProviderInterfaceTest extends TestCase
 {
 	public function testProvider()
 	{

--- a/tests/PimpleCopy/Pimple/PimpleTest.php
+++ b/tests/PimpleCopy/Pimple/PimpleTest.php
@@ -26,12 +26,13 @@
 
 namespace tests\PimpleCopy\Pimple;
 
+use PHPUnit\Framework\TestCase;
 use PimpleCopy\Pimple\Container;
 
 /**
  * @author  Igor Wiedler <igor@wiedler.ch>
  */
-class PimpleTest extends \PHPUnit_Framework_TestCase
+class PimpleTest extends TestCase
 {
 	public function testWithString()
 	{

--- a/tests/aik099/PHPUnit/ApplicationTest.php
+++ b/tests/aik099/PHPUnit/ApplicationTest.php
@@ -13,8 +13,9 @@ namespace tests\aik099\PHPUnit;
 
 use aik099\PHPUnit\Application;
 use Mockery as m;
+use PHPUnit\Framework\TestCase;
 
-class ApplicationTest extends \PHPUnit_Framework_TestCase
+class ApplicationTest extends TestCase
 {
 
 	/**

--- a/tests/aik099/PHPUnit/Event/TestEventTest.php
+++ b/tests/aik099/PHPUnit/Event/TestEventTest.php
@@ -15,8 +15,9 @@ use aik099\PHPUnit\BrowserTestCase;
 use aik099\PHPUnit\Event\TestEvent;
 use Behat\Mink\Session;
 use Mockery as m;
+use PHPUnit\Framework\TestCase;
 
-class TestEventTest extends \PHPUnit_Framework_TestCase
+class TestEventTest extends TestCase
 {
 
 	/**

--- a/tests/aik099/PHPUnit/Integration/ApiIntegrationTest.php
+++ b/tests/aik099/PHPUnit/Integration/ApiIntegrationTest.php
@@ -11,10 +11,10 @@
 namespace tests\aik099\PHPUnit\Integration;
 
 
-use Mockery as m;
+use PHPUnit\Framework\TestCase;
 use tests\aik099\PHPUnit\Fixture\ApiIntegrationFixture;
 
-class ApiIntegrationTest extends \PHPUnit_Framework_TestCase
+class ApiIntegrationTest extends TestCase
 {
 
 	protected function setUp()

--- a/tests/aik099/PHPUnit/Integration/DIContainerTest.php
+++ b/tests/aik099/PHPUnit/Integration/DIContainerTest.php
@@ -13,9 +13,9 @@ namespace tests\aik099\PHPUnit\Integration;
 
 use aik099\PHPUnit\Application;
 use aik099\PHPUnit\DIContainer;
-use Mockery as m;
+use PHPUnit\Framework\TestCase;
 
-class DIContainerTest extends \PHPUnit_Framework_TestCase
+class DIContainerTest extends TestCase
 {
 
 	/**

--- a/tests/aik099/PHPUnit/Integration/EventDispatchingTest.php
+++ b/tests/aik099/PHPUnit/Integration/EventDispatchingTest.php
@@ -11,10 +11,10 @@
 namespace tests\aik099\PHPUnit\Integration;
 
 
-use Mockery as m;
+use PHPUnit\Framework\TestCase;
 use tests\aik099\PHPUnit\Fixture\SetupEventFixture;
 
-class EventDispatchingTest extends \PHPUnit_Framework_TestCase
+class EventDispatchingTest extends TestCase
 {
 
 	protected function setUp()

--- a/tests/aik099/PHPUnit/Integration/SuiteBuildingTest.php
+++ b/tests/aik099/PHPUnit/Integration/SuiteBuildingTest.php
@@ -13,11 +13,12 @@ namespace tests\aik099\PHPUnit\Integration;
 
 use aik099\PHPUnit\TestSuite\BrowserTestSuite;
 use aik099\PHPUnit\TestSuite\RegularTestSuite;
+use PHPUnit\Framework\TestCase;
 use tests\aik099\PHPUnit\Fixture\WithBrowserConfig;
 use tests\aik099\PHPUnit\Fixture\WithoutBrowserConfig;
 use Mockery as m;
 
-class SuiteBuildingTest extends \PHPUnit_Framework_TestCase
+class SuiteBuildingTest extends TestCase
 {
 
 	const SUITE_CLASS = '\\aik099\\PHPUnit\\TestSuite\\RegularTestSuite';

--- a/tests/aik099/PHPUnit/MinkDriver/DriverFactoryRegistryTest.php
+++ b/tests/aik099/PHPUnit/MinkDriver/DriverFactoryRegistryTest.php
@@ -14,8 +14,9 @@ namespace tests\aik099\PHPUnit\MinkDriver;
 
 use aik099\PHPUnit\MinkDriver\DriverFactoryRegistry;
 use Mockery as m;
+use PHPUnit\Framework\TestCase;
 
-class DriverFactoryRegistryTest extends \PHPUnit_Framework_TestCase
+class DriverFactoryRegistryTest extends TestCase
 {
 
 	/**

--- a/tests/aik099/PHPUnit/MinkDriver/DriverFactoryTest.php
+++ b/tests/aik099/PHPUnit/MinkDriver/DriverFactoryTest.php
@@ -16,8 +16,9 @@ use aik099\PHPUnit\BrowserConfiguration\BrowserConfiguration;
 use aik099\PHPUnit\DIContainer;
 use aik099\PHPUnit\MinkDriver\IMinkDriverFactory;
 use Mockery as m;
+use PHPUnit\Framework\TestCase;
 
-class DriverFactoryTest extends \PHPUnit_Framework_TestCase
+class DriverFactoryTest extends TestCase
 {
 
 	/**

--- a/tests/aik099/PHPUnit/RemoteCoverage/RemoteCoverageHelperTest.php
+++ b/tests/aik099/PHPUnit/RemoteCoverage/RemoteCoverageHelperTest.php
@@ -15,8 +15,9 @@ use aik099\PHPUnit\RemoteCoverage\RemoteCoverageHelper;
 use aik099\PHPUnit\RemoteCoverage\RemoteUrl;
 use Mockery as m;
 use Mockery\MockInterface;
+use PHPUnit\Framework\TestCase;
 
-class RemoteCoverageHelperTest extends \PHPUnit_Framework_TestCase
+class RemoteCoverageHelperTest extends TestCase
 {
 
 	/**

--- a/tests/aik099/PHPUnit/RemoteCoverage/RemoteUrlTest.php
+++ b/tests/aik099/PHPUnit/RemoteCoverage/RemoteUrlTest.php
@@ -12,8 +12,9 @@ namespace tests\aik099\PHPUnit\RemoteCoverage;
 
 
 use aik099\PHPUnit\RemoteCoverage\RemoteUrl;
+use PHPUnit\Framework\TestCase;
 
-class RemoteUrlTest extends \PHPUnit_Framework_TestCase
+class RemoteUrlTest extends TestCase
 {
 
 	/**

--- a/tests/aik099/PHPUnit/Session/SessionFactoryTest.php
+++ b/tests/aik099/PHPUnit/Session/SessionFactoryTest.php
@@ -13,8 +13,9 @@ namespace tests\aik099\PHPUnit\Session;
 
 use aik099\PHPUnit\Session\SessionFactory;
 use Mockery as m;
+use PHPUnit\Framework\TestCase;
 
-class SessionFactoryTest extends \PHPUnit_Framework_TestCase
+class SessionFactoryTest extends TestCase
 {
 
 	/**

--- a/tests/aik099/PHPUnit/Session/SessionStrategyManagerTest.php
+++ b/tests/aik099/PHPUnit/Session/SessionStrategyManagerTest.php
@@ -16,8 +16,9 @@ use aik099\PHPUnit\Session\ISessionStrategyFactory;
 use aik099\PHPUnit\Session\SessionStrategyFactory;
 use aik099\PHPUnit\Session\SessionStrategyManager;
 use Mockery as m;
+use PHPUnit\Framework\TestCase;
 
-class SessionStrategyManagerTest extends \PHPUnit_Framework_TestCase
+class SessionStrategyManagerTest extends TestCase
 {
 
 	/**

--- a/tests/aik099/PHPUnit/Session/SessionStrategyTestCase.php
+++ b/tests/aik099/PHPUnit/Session/SessionStrategyTestCase.php
@@ -12,10 +12,10 @@ namespace tests\aik099\PHPUnit\Session;
 
 
 use aik099\PHPUnit\Session\ISessionStrategy;
-use Mockery as m;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 
-class SessionStrategyTestCase extends \PHPUnit_Framework_TestCase
+class SessionStrategyTestCase extends TestCase
 {
 
 	const BROWSER_CLASS = '\\aik099\\PHPUnit\\BrowserConfiguration\\BrowserConfiguration';

--- a/tests/aik099/PHPUnit/TestCase/ApplicationAwareTestCase.php
+++ b/tests/aik099/PHPUnit/TestCase/ApplicationAwareTestCase.php
@@ -14,8 +14,9 @@ namespace tests\aik099\PHPUnit\TestCase;
 use aik099\PHPUnit\Application;
 use Mockery\MockInterface;
 use Mockery as m;
+use PHPUnit\Framework\TestCase;
 
-class ApplicationAwareTestCase extends \PHPUnit_Framework_TestCase
+class ApplicationAwareTestCase extends TestCase
 {
 
 	/**

--- a/tests/aik099/PHPUnit/TestCase/EventDispatcherAwareTestCase.php
+++ b/tests/aik099/PHPUnit/TestCase/EventDispatcherAwareTestCase.php
@@ -13,9 +13,10 @@ namespace tests\aik099\PHPUnit\TestCase;
 
 use Mockery\MockInterface;
 use Mockery as m;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
-class EventDispatcherAwareTestCase extends \PHPUnit_Framework_TestCase
+class EventDispatcherAwareTestCase extends TestCase
 {
 
 	/**


### PR DESCRIPTION
This is related to #93 

Not all PHPUnit classes are used with namespace, following are missing and will be handled in PR for PHPUnit 6 compatibility:
* \PHPUnit_Framework_TestResult
* \PHPUnit_Framework_IncompleteTestError
* \PHPUnit_Framework_SkippedTestError
* \PHPUnit_Framework_TestSuite_DataProvider