### PR TITLE
Correctly handle Error on PHP7

### DIFF
--- a/library/aik099/PHPUnit/AbstractPHPUnitCompatibilityTestCase.php
+++ b/library/aik099/PHPUnit/AbstractPHPUnitCompatibilityTestCase.php
@@ -28,7 +28,7 @@ if ( version_compare(\PHPUnit_Runner_Version::id(), '5.0.0', '>=') ) {
 		/**
 		 * This method is called when a test method did not execute successfully.
 		 *
-		 * @param \Exception $e Exception.
+		 * @param \Throwable $e Exception or error.
 		 *
 		 * @return void
 		 */
@@ -42,11 +42,11 @@ if ( version_compare(\PHPUnit_Runner_Version::id(), '5.0.0', '>=') ) {
 		/**
 		 * This method is called when a test method did not execute successfully.
 		 *
-		 * @param \Exception $e Exception.
+		 * @param \Throwable $e Exception or error.
 		 *
 		 * @return void
 		 */
-		abstract protected function onNotSuccessfulTestCompatibilized(\Exception $e);
+		abstract protected function onNotSuccessfulTestCompatibilized($e);
 
 	}
 }
@@ -76,11 +76,11 @@ else {
 		/**
 		 * This method is called when a test method did not execute successfully.
 		 *
-		 * @param \Exception $e Exception.
+		 * @param \Throwable $e Exception or error.
 		 *
 		 * @return void
 		 */
-		abstract protected function onNotSuccessfulTestCompatibilized(\Exception $e);
+		abstract protected function onNotSuccessfulTestCompatibilized($e);
 
 	}
 }

--- a/library/aik099/PHPUnit/BrowserTestCase.php
+++ b/library/aik099/PHPUnit/BrowserTestCase.php
@@ -415,11 +415,11 @@ abstract class BrowserTestCase extends AbstractPHPUnitCompatibilityTestCase impl
 	/**
 	 * This method is called when a test method did not execute successfully.
 	 *
-	 * @param \Exception $e Exception.
+	 * @param \Throwable $e Exception or error.
 	 *
 	 * @return void
 	 */
-	protected function onNotSuccessfulTestCompatibilized(\Exception $e)
+	protected function onNotSuccessfulTestCompatibilized($e)
 	{
 		$this->_eventDispatcher->dispatch(
 			self::TEST_FAILED_EVENT,

--- a/library/aik099/PHPUnit/Event/TestFailedEvent.php
+++ b/library/aik099/PHPUnit/Event/TestFailedEvent.php
@@ -18,29 +18,29 @@ class TestFailedEvent extends TestEvent
 {
 
 	/**
-	 * Exception.
+	 * Exception or error.
 	 *
-	 * @var \Exception
+	 * @var \Throwable
 	 */
 	private $_exception;
 
 	/**
 	 * Remembers the exception which caused test to fail.
 	 *
-	 * @param \Exception      $e         Exception.
+	 * @param \Throwable      $e         Exception or error.
 	 * @param BrowserTestCase $test_case Test case.
 	 * @param Session         $session   Session.
 	 */
-	public function __construct(\Exception $e, BrowserTestCase $test_case, Session $session = null)
+	public function __construct($e, BrowserTestCase $test_case, Session $session = null)
 	{
 		parent::__construct($test_case, $session);
 		$this->_exception = $e;
 	}
 
 	/**
-	 * Returns exception, that caused test to fail.
+	 * Returns exception or error, that caused test to fail.
 	 *
-	 * @return \Exception
+	 * @return \Throwable
 	 */
 	public function getException()
 	{


### PR DESCRIPTION
PHP7 introduced the Error class and Throwable interface.
Fatal errors like calls to undefined methods are "Error" now.
We cannot limit the error handler to "Exception" only anymore.

Resolves: https://github.com/minkphp/phpunit-mink/issues/97