### PR TITLE
Exclude assertion methods during the test suite building

### DIFF
--- a/library/aik099/PHPUnit/TestSuite/AbstractTestSuite.php
+++ b/library/aik099/PHPUnit/TestSuite/AbstractTestSuite.php
@@ -68,13 +68,13 @@ abstract class AbstractTestSuite extends AbstractPHPUnitCompatibilityTestSuite i
 
 		if ( \method_exists($this, 'isTestMethod') ) {
 			// PHPUnit < 8.0 is calling "isTestMethod" inside "TestSuite::addTestMethod".
-			foreach ( $class->getMethods(\ReflectionMethod::IS_PUBLIC) as $method ) {
+			foreach ( $this->getTestMethods($class) as $method ) {
 				$this->addTestMethod($class, $method);
 			}
 		}
 		else {
 			// PHPUnit >= 8.0 is calling "TestUtil::isTestMethod" outside of "TestSuite::addTestMethod".
-			foreach ( $class->getMethods(\ReflectionMethod::IS_PUBLIC) as $method ) {
+			foreach ( $this->getTestMethods($class) as $method ) {
 				if ( TestUtil::isTestMethod($method) ) {
 					$this->addTestMethod($class, $method);
 				}
@@ -82,6 +82,22 @@ abstract class AbstractTestSuite extends AbstractPHPUnitCompatibilityTestSuite i
 		}
 
 		return $this;
+	}
+
+	/**
+	 * Returns test methods.
+	 *
+	 * @param \ReflectionClass $class Reflection class.
+	 *
+	 * @return \ReflectionMethod[]
+	 */
+	protected function getTestMethods(\ReflectionClass $class)
+	{
+		$ret = $class->getMethods(\ReflectionMethod::IS_PUBLIC);
+
+		return \array_filter($ret, function (\ReflectionMethod $method) {
+			return !$method->isStatic();
+		});
 	}
 
 	/**


### PR DESCRIPTION
Currently, a test case class with a single test contains ~300 public methods. The 2/3 of them are static methods (likely related to assertions).

Excluding these static public methods from the test suite building should speed up things.