### PR TITLE
Reduce some "BrowserTestCase" class method visibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Allow using self-signed/invalid SSL certificates during testing on the SauceLabs by default.
 - Rewritten library object communication mechanism (the event dispatcher is no longer used). Update any custom session strategy/browser configuration implementations.
 - Reduce memory consumption by rewriting `SessionStrategyFactory` and `SessionStrategyManager` classes.
+- (Not a BC break) Some public methods of the `BrowserTestCase` class are protected now. Affected methods: `setRemoteCoverageScriptUrl`, `setBrowser`, `getBrowser`, `setSessionStrategy`, `getSessionStrategy`, `getCollectCodeCoverageInformation`, `getRemoteCodeCoverageInformation`.
+- (Not a BC break) Some protected properties of the `BrowserTestCase` class are private now. Affected properties: `sessionStrategyManager`, `remoteCoverageHelper`, `sessionStrategy`.
 
 ### Fixed
 - Don't set remote code coverage collection cookies, when the remote code coverage script URL isn't specified.

--- a/library/aik099/PHPUnit/BrowserTestCase.php
+++ b/library/aik099/PHPUnit/BrowserTestCase.php
@@ -71,21 +71,21 @@ abstract class BrowserTestCase extends AbstractTestCase
 	 *
 	 * @var SessionStrategyManager
 	 */
-	protected $sessionStrategyManager;
+	private $_sessionStrategyManager;
 
 	/**
 	 * Remote coverage helper.
 	 *
 	 * @var RemoteCoverageHelper
 	 */
-	protected $remoteCoverageHelper;
+	private $_remoteCoverageHelper;
 
 	/**
 	 * Session strategy, used currently.
 	 *
 	 * @var ISessionStrategy
 	 */
-	protected $sessionStrategy;
+	private $_sessionStrategy;
 
 	/**
 	 * Test ID.
@@ -115,7 +115,7 @@ abstract class BrowserTestCase extends AbstractTestCase
 	 */
 	public function setSessionStrategyManager(SessionStrategyManager $session_strategy_manager)
 	{
-		$this->sessionStrategyManager = $session_strategy_manager;
+		$this->_sessionStrategyManager = $session_strategy_manager;
 
 		return $this;
 	}
@@ -129,7 +129,7 @@ abstract class BrowserTestCase extends AbstractTestCase
 	 */
 	public function setRemoteCoverageHelper(RemoteCoverageHelper $remote_coverage_helper)
 	{
-		$this->remoteCoverageHelper = $remote_coverage_helper;
+		$this->_remoteCoverageHelper = $remote_coverage_helper;
 	}
 
 	/**
@@ -139,7 +139,7 @@ abstract class BrowserTestCase extends AbstractTestCase
 	 *
 	 * @return void
 	 */
-	public function setRemoteCoverageScriptUrl($url)
+	protected function setRemoteCoverageScriptUrl($url)
 	{
 		$this->_remoteCoverageScriptUrl = $url;
 	}
@@ -164,14 +164,16 @@ abstract class BrowserTestCase extends AbstractTestCase
 	 *
 	 * @return self
 	 */
-	public function setBrowser(BrowserConfiguration $browser)
+	protected function setBrowser(BrowserConfiguration $browser)
 	{
 		$this->_browser = $browser;
 
 		// Configure session strategy.
-		return $this->setSessionStrategy(
-			$this->sessionStrategyManager->getSessionStrategy($browser, $this)
+		$this->setSessionStrategy(
+			$this->_sessionStrategyManager->getSessionStrategy($browser, $this)
 		);
+
+		return $this;
 	}
 
 	/**
@@ -180,7 +182,7 @@ abstract class BrowserTestCase extends AbstractTestCase
 	 * @return BrowserConfiguration
 	 * @throws \RuntimeException When browser configuration isn't defined.
 	 */
-	public function getBrowser()
+	protected function getBrowser()
 	{
 		if ( !is_object($this->_browser) ) {
 			throw new \RuntimeException('Browser configuration not defined');
@@ -198,7 +200,9 @@ abstract class BrowserTestCase extends AbstractTestCase
 	 */
 	public function setBrowserFromConfiguration(array $browser_config)
 	{
-		return $this->setBrowser($this->createBrowserConfiguration($browser_config));
+		return $this->setBrowser(
+			$this->createBrowserConfiguration($browser_config)
+		);
 	}
 
 	/**
@@ -220,9 +224,9 @@ abstract class BrowserTestCase extends AbstractTestCase
 	 *
 	 * @return self
 	 */
-	public function setSessionStrategy(ISessionStrategy $session_strategy = null)
+	protected function setSessionStrategy(ISessionStrategy $session_strategy = null)
 	{
-		$this->sessionStrategy = $session_strategy;
+		$this->_sessionStrategy = $session_strategy;
 
 		return $this;
 	}
@@ -233,14 +237,14 @@ abstract class BrowserTestCase extends AbstractTestCase
 	 * @return ISessionStrategy
 	 * @see    setSessionStrategy()
 	 */
-	public function getSessionStrategy()
+	protected function getSessionStrategy()
 	{
-		if ( $this->sessionStrategy ) {
-			return $this->sessionStrategy;
+		if ( $this->_sessionStrategy !== null ) {
+			return $this->_sessionStrategy;
 		}
 
 		// Default session strategy (not session itself) shared across all test cases.
-		return $this->sessionStrategyManager->getDefaultSessionStrategy();
+		return $this->_sessionStrategyManager->getDefaultSessionStrategy();
 	}
 
 	/**
@@ -290,8 +294,8 @@ abstract class BrowserTestCase extends AbstractTestCase
 			$this->_browser->onTestEnded($this, $result);
 		}
 
-		if ( $this->sessionStrategy !== null ) {
-			$this->sessionStrategy->onTestEnded($this);
+		if ( $this->_sessionStrategy !== null ) {
+			$this->_sessionStrategy->onTestEnded($this);
 		}
 	}
 
@@ -301,7 +305,7 @@ abstract class BrowserTestCase extends AbstractTestCase
 	 * @return boolean
 	 * @throws \RuntimeException When used before test is started.
 	 */
-	public function getCollectCodeCoverageInformation()
+	protected function getCollectCodeCoverageInformation()
 	{
 		if ( !$this->_remoteCoverageScriptUrl ) {
 			return false;
@@ -341,8 +345,8 @@ abstract class BrowserTestCase extends AbstractTestCase
 	 */
 	public function onTestSuiteEnded()
 	{
-		if ( $this->sessionStrategy !== null ) {
-			$this->sessionStrategy->onTestSuiteEnded($this);
+		if ( $this->_sessionStrategy !== null ) {
+			$this->_sessionStrategy->onTestSuiteEnded($this);
 		}
 
 		return $this;
@@ -353,13 +357,13 @@ abstract class BrowserTestCase extends AbstractTestCase
 	 *
 	 * @return array|RawCodeCoverageData
 	 */
-	public function getRemoteCodeCoverageInformation()
+	protected function getRemoteCodeCoverageInformation()
 	{
 		if ( $this->_remoteCoverageScriptUrl ) {
-			return $this->remoteCoverageHelper->get($this->_remoteCoverageScriptUrl, $this->_testId);
+			return $this->_remoteCoverageHelper->get($this->_remoteCoverageScriptUrl, $this->_testId);
 		}
 
-		return $this->remoteCoverageHelper->getEmpty();
+		return $this->_remoteCoverageHelper->getEmpty();
 	}
 
 	/**
@@ -381,8 +385,8 @@ abstract class BrowserTestCase extends AbstractTestCase
 	 */
 	protected function onNotSuccessfulTestCompat($e)
 	{
-		if ( $this->sessionStrategy !== null ) {
-			$this->sessionStrategy->onTestFailed($this, $e);
+		if ( $this->_sessionStrategy !== null ) {
+			$this->_sessionStrategy->onTestFailed($this, $e);
 		}
 	}
 

--- a/tests/aik099/PHPUnit/Integration/SuiteBuildingTest.php
+++ b/tests/aik099/PHPUnit/Integration/SuiteBuildingTest.php
@@ -49,12 +49,15 @@ class SuiteBuildingTest extends AbstractTestCase
 
 		$this->checkArray($test_suites, 2, self::BROWSER_SUITE_CLASS);
 
+		$property = new \ReflectionProperty(BrowserTestCase::class, '_sessionStrategy');
+		$property->setAccessible(true);
+
 		foreach ( $test_suites as $test_suite ) {
 			/** @var BrowserTestCase[] $suite_tests */
 			$suite_tests = $test_suite->tests();
 			$this->checkArray($suite_tests, 2, self::TEST_CASE_WITH_CONFIG);
 
-			$this->assertInstanceOf(ISessionStrategy::class, $suite_tests[0]->getSessionStrategy());
+			$this->assertInstanceOf(ISessionStrategy::class, $property->getValue($suite_tests[0]));
 		}
 	}
 


### PR DESCRIPTION
* Some of the `BrowserTestCase` class methods were publicly accessible only for testing purposes. Now these methods have `protected` visibility.
* Some of the `BrowserTestCase` properties, that were not supposed to be directly accessed by the class descendants had `protected` visibility. That is fixed now.