### PR TITLE
Invoke "BrowserTestCase::onTestSuiteEnded" method only for executed tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 - Don't set remote code coverage collection cookies, when the remote code coverage script URL isn't specified.
+- The `BrowserTestCase::onTestSuiteEnded` method was called for tests, excluded through the `--filter` option of the PHPUnit.
 
 ## [2.3.0] - 2022-11-24
 ### Changed

--- a/library/aik099/PHPUnit/TestSuite/AbstractTestSuite.php
+++ b/library/aik099/PHPUnit/TestSuite/AbstractTestSuite.php
@@ -134,24 +134,24 @@ abstract class AbstractTestSuite extends PHPUnitCompatAbstractTestSuite
 	/**
 	 * Report back suite ending to each it's test.
 	 *
-	 * @param array $tests Tests to process.
+	 * @param \IteratorAggregate|null $test_suite Test suite.
 	 *
 	 * @return void
 	 */
-	protected function triggerTestSuiteEnded(array $tests = null)
+	protected function triggerTestSuiteEnded(\IteratorAggregate $test_suite = null)
 	{
-		if ( !isset($tests) ) {
-			$tests = $this->tests();
+		if ( $test_suite === null ) {
+			$test_suite = $this;
 		}
 
-		foreach ( $tests as $test ) {
+		foreach ( $test_suite as $test ) {
 			if ( $test instanceof DataProviderTestSuite ) {
 				/*
 				 * Use our test suite method to tear down
 				 * supported test suites wrapped in a data
 				 * provider test suite.
 				 */
-				$this->triggerTestSuiteEnded($test->tests());
+				$this->triggerTestSuiteEnded($test);
 			}
 			else {
 				/*


### PR DESCRIPTION
The `BrowserTestCase::onTestSuiteEnded` event was also invoked for excluded tests. This happened because tests for iteration were retrieved from the `TestSuite::tests` method (which returns all tests and even those, that won't be executed).

Instead, interaction should be made through the `TestSuite` class object itself (as PHPUnit does). This has been fixed by this PR.