### PR TITLE
Simplify driver installation process

### DIFF
--- a/library/aik099/PHPUnit/MinkDriver/AbstractDriverFactory.php
+++ b/library/aik099/PHPUnit/MinkDriver/AbstractDriverFactory.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * This file is part of the phpunit-mink library.
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @copyright Alexander Obuhovich <aik.bold@gmail.com>
+ * @link      https://github.com/aik099/phpunit-mink
+ */
+
+
+namespace aik099\PHPUnit\MinkDriver;
+
+
+abstract class AbstractDriverFactory implements IMinkDriverFactory
+{
+
+	/**
+	 * Throws an exception with driver installation instructions.
+	 *
+	 * @param string $class_name Driver class name.
+	 *
+	 * @return void
+	 * @throws \RuntimeException When driver isn't installed.
+	 */
+	protected function assertInstalled($class_name)
+	{
+		if ( !class_exists($class_name) ) {
+			throw new \RuntimeException(
+				sprintf(
+					'The "%s" driver package is not installed. Please follow installation instructions at %s.',
+					$this->getDriverName(),
+					$this->getDriverPackageUrl()
+				)
+			);
+		}
+	}
+
+}

--- a/library/aik099/PHPUnit/MinkDriver/GoutteDriverFactory.php
+++ b/library/aik099/PHPUnit/MinkDriver/GoutteDriverFactory.php
@@ -13,9 +13,8 @@ namespace aik099\PHPUnit\MinkDriver;
 
 
 use aik099\PHPUnit\BrowserConfiguration\BrowserConfiguration;
-use Behat\Mink\Driver\DriverInterface;
 
-class GoutteDriverFactory implements IMinkDriverFactory
+class GoutteDriverFactory extends AbstractDriverFactory
 {
 
 	/**
@@ -26,6 +25,14 @@ class GoutteDriverFactory implements IMinkDriverFactory
 	public function getDriverName()
 	{
 		return 'goutte';
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function getDriverPackageUrl()
+	{
+		return 'https://packagist.org/packages/behat/mink-goutte-driver';
 	}
 
 	/**
@@ -44,20 +51,11 @@ class GoutteDriverFactory implements IMinkDriverFactory
 	}
 
 	/**
-	 * Returns a new driver instance according to the browser configuration.
-	 *
-	 * @param BrowserConfiguration $browser The browser configuration.
-	 *
-	 * @return DriverInterface
-	 * @throws \RuntimeException When driver isn't installed.
+	 * @inheritDoc
 	 */
 	public function createDriver(BrowserConfiguration $browser)
 	{
-		if ( !class_exists('Behat\Mink\Driver\GoutteDriver') ) {
-			throw new \RuntimeException(
-				'Install MinkGoutteDriver in order to use goutte driver.'
-			);
-		}
+		$this->assertInstalled('Behat\Mink\Driver\GoutteDriver');
 
 		$driver_options = $browser->getDriverOptions();
 

--- a/library/aik099/PHPUnit/MinkDriver/IMinkDriverFactory.php
+++ b/library/aik099/PHPUnit/MinkDriver/IMinkDriverFactory.php
@@ -26,6 +26,13 @@ interface IMinkDriverFactory
 	public function getDriverName();
 
 	/**
+	 * Returns driver package URL.
+	 *
+	 * @return string
+	 */
+	public function getDriverPackageUrl();
+
+	/**
 	 * Returns default values for browser configuration.
 	 *
 	 * @return array
@@ -38,6 +45,7 @@ interface IMinkDriverFactory
 	 * @param BrowserConfiguration $browser The browser configuration.
 	 *
 	 * @return DriverInterface
+	 * @throws \RuntimeException When driver isn't installed.
 	 */
 	public function createDriver(BrowserConfiguration $browser);
 

--- a/library/aik099/PHPUnit/MinkDriver/SahiDriverFactory.php
+++ b/library/aik099/PHPUnit/MinkDriver/SahiDriverFactory.php
@@ -13,9 +13,8 @@ namespace aik099\PHPUnit\MinkDriver;
 
 
 use aik099\PHPUnit\BrowserConfiguration\BrowserConfiguration;
-use Behat\Mink\Driver\DriverInterface;
 
-class SahiDriverFactory implements IMinkDriverFactory
+class SahiDriverFactory extends AbstractDriverFactory
 {
 
 	/**
@@ -26,6 +25,14 @@ class SahiDriverFactory implements IMinkDriverFactory
 	public function getDriverName()
 	{
 		return 'sahi';
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function getDriverPackageUrl()
+	{
+		return 'https://packagist.org/packages/behat/mink-sahi-driver';
 	}
 
 	/**
@@ -46,20 +53,11 @@ class SahiDriverFactory implements IMinkDriverFactory
 	}
 
 	/**
-	 * Returns a new driver instance according to the browser configuration.
-	 *
-	 * @param BrowserConfiguration $browser The browser configuration.
-	 *
-	 * @return DriverInterface
-	 * @throws \RuntimeException When driver isn't installed.
+	 * @inheritDoc
 	 */
 	public function createDriver(BrowserConfiguration $browser)
 	{
-		if ( !class_exists('Behat\Mink\Driver\SahiDriver') ) {
-			throw new \RuntimeException(
-				'Install MinkSahiDriver in order to use sahi driver.'
-			);
-		}
+		$this->assertInstalled('Behat\Mink\Driver\SahiDriver');
 
 		$driver_options = $browser->getDriverOptions();
 

--- a/library/aik099/PHPUnit/MinkDriver/Selenium2DriverFactory.php
+++ b/library/aik099/PHPUnit/MinkDriver/Selenium2DriverFactory.php
@@ -13,9 +13,8 @@ namespace aik099\PHPUnit\MinkDriver;
 
 
 use aik099\PHPUnit\BrowserConfiguration\BrowserConfiguration;
-use Behat\Mink\Driver\DriverInterface;
 
-class Selenium2DriverFactory implements IMinkDriverFactory
+class Selenium2DriverFactory extends AbstractDriverFactory
 {
 
 	/**
@@ -26,6 +25,14 @@ class Selenium2DriverFactory implements IMinkDriverFactory
 	public function getDriverName()
 	{
 		return 'selenium2';
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function getDriverPackageUrl()
+	{
+		return 'https://packagist.org/packages/behat/mink-selenium2-driver';
 	}
 
 	/**
@@ -42,20 +49,11 @@ class Selenium2DriverFactory implements IMinkDriverFactory
 	}
 
 	/**
-	 * Returns a new driver instance according to the browser configuration.
-	 *
-	 * @param BrowserConfiguration $browser The browser configuration.
-	 *
-	 * @return DriverInterface
-	 * @throws \RuntimeException When driver isn't installed.
+	 * @inheritDoc
 	 */
 	public function createDriver(BrowserConfiguration $browser)
 	{
-		if ( !class_exists('Behat\Mink\Driver\Selenium2Driver') ) {
-			throw new \RuntimeException(
-				'Install MinkSelenium2Driver in order to use selenium2 driver.'
-			);
-		}
+		$this->assertInstalled('Behat\Mink\Driver\Selenium2Driver');
 
 		$browser_name = $browser->getBrowserName();
 		$capabilities = $browser->getDesiredCapabilities();

--- a/library/aik099/PHPUnit/MinkDriver/ZombieDriverFactory.php
+++ b/library/aik099/PHPUnit/MinkDriver/ZombieDriverFactory.php
@@ -13,9 +13,8 @@ namespace aik099\PHPUnit\MinkDriver;
 
 
 use aik099\PHPUnit\BrowserConfiguration\BrowserConfiguration;
-use Behat\Mink\Driver\DriverInterface;
 
-class ZombieDriverFactory implements IMinkDriverFactory
+class ZombieDriverFactory extends AbstractDriverFactory
 {
 
 	/**
@@ -26,6 +25,14 @@ class ZombieDriverFactory implements IMinkDriverFactory
 	public function getDriverName()
 	{
 		return 'zombie';
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function getDriverPackageUrl()
+	{
+		return 'https://packagist.org/packages/behat/mink-zombie-driver';
 	}
 
 	/**
@@ -47,20 +54,11 @@ class ZombieDriverFactory implements IMinkDriverFactory
 	}
 
 	/**
-	 * Returns a new driver instance according to the browser configuration.
-	 *
-	 * @param BrowserConfiguration $browser The browser configuration.
-	 *
-	 * @return DriverInterface
-	 * @throws \RuntimeException When driver isn't installed.
+	 * @inheritDoc
 	 */
 	public function createDriver(BrowserConfiguration $browser)
 	{
-		if ( !class_exists('Behat\Mink\Driver\ZombieDriver') ) {
-			throw new \RuntimeException(
-				'Install MinkZombieDriver in order to use zombie driver.'
-			);
-		}
+		$this->assertInstalled('Behat\Mink\Driver\ZombieDriver');
 
 		$driver_options = $browser->getDriverOptions();
 

--- a/tests/aik099/PHPUnit/MinkDriver/DriverFactoryTest.php
+++ b/tests/aik099/PHPUnit/MinkDriver/DriverFactoryTest.php
@@ -53,11 +53,14 @@ class DriverFactoryTest extends AbstractTestCase
 
 		/** @var IMinkDriverFactory $factory */
 		$factory = new $factory_class();
-		$driver_class_parts = explode('\\', $driver_class);
 
 		$this->expectException('RuntimeException');
 		$this->expectExceptionMessage(
-			'Install Mink' . end($driver_class_parts) . ' in order to use ' . $factory->getDriverName() . ' driver.'
+			sprintf(
+				'The "%s" driver package is not installed. Please follow installation instructions at %s.',
+				$factory->getDriverName(),
+				$factory->getDriverPackageUrl()
+			)
 		);
 		$factory->createDriver($this->createBrowserConfiguration($factory));
 	}


### PR DESCRIPTION
Changed error message formatting, that is shown, when driver package isn't installed.

### Before PR:
```
Install MinkSelenium2Driver in order to use selenium2 driver.
```

### After PR:
```
The "selenium2" driver package is not installed. Please follow installation instructions at https://packagist.org/packages/behat/mink-selenium2-driver.
```