### PR TITLE
Improve error, when unknown driver is being used

### DIFF
--- a/library/aik099/PHPUnit/MinkDriver/DriverFactoryRegistry.php
+++ b/library/aik099/PHPUnit/MinkDriver/DriverFactoryRegistry.php
@@ -52,7 +52,14 @@ class DriverFactoryRegistry
 	public function get($driver_name)
 	{
 		if ( !isset($this->_registry[$driver_name]) ) {
-			throw new \OutOfBoundsException(sprintf('No driver factory for "%s" driver.', $driver_name));
+			$error_msg = 'The "' . $driver_name . '" driver is unknown.';
+
+			if ( $this->_registry ) {
+				$drivers = '"' . implode('", "', array_keys($this->_registry)) . '"';
+				$error_msg .= ' Please instead use any of these supported drivers: ' . $drivers . '.';
+			}
+
+			throw new \OutOfBoundsException($error_msg);
 		}
 
 		return $this->_registry[$driver_name];

--- a/tests/aik099/PHPUnit/MinkDriver/DriverFactoryRegistryTest.php
+++ b/tests/aik099/PHPUnit/MinkDriver/DriverFactoryRegistryTest.php
@@ -60,10 +60,28 @@ class DriverFactoryRegistryTest extends AbstractTestCase
 		$this->_driverFactoryRegistry->add($factory);
 	}
 
-	public function testGettingNonExisting()
+	public function testGettingNonExistingWithoutAlternatives()
 	{
 		$this->expectException('OutOfBoundsException');
-		$this->expectExceptionMessage('No driver factory for "test" driver.');
+		$this->expectExceptionMessage('The "test" driver is unknown.');
+
+		$this->_driverFactoryRegistry->get('test');
+	}
+
+	public function testGettingNonExistingWithAlternatives()
+	{
+		$this->expectException('OutOfBoundsException');
+		$this->expectExceptionMessage(
+			'The "test" driver is unknown. Please instead use any of these supported drivers: "driver1", "driver2".'
+		);
+
+		$factory1 = m::mock(IMinkDriverFactory::class);
+		$factory1->shouldReceive('getDriverName')->once()->andReturn('driver1');
+		$this->_driverFactoryRegistry->add($factory1);
+
+		$factory2 = m::mock(IMinkDriverFactory::class);
+		$factory2->shouldReceive('getDriverName')->once()->andReturn('driver2');
+		$this->_driverFactoryRegistry->add($factory2);
 
 		$this->_driverFactoryRegistry->get('test');
 	}


### PR DESCRIPTION
When a developer have used a non-existing driver name, then inform him about possible valid driver names.

Before PR:
```
No driver factory for "unknown" driver.
```

After PR:
```
The "unknown" driver is unknown. Please instead use any of these supported drivers: "selenium2", "sahi", "goutte", "zombie".
```