### PR TITLE
Closes popups after test finishes (shared strategy)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - (Not a BC break) Some public methods of the `BrowserTestCase` class are protected now. Affected methods: `setRemoteCoverageScriptUrl`, `setBrowser`, `getBrowser`, `setSessionStrategy`, `getSessionStrategy`, `getCollectCodeCoverageInformation`, `getRemoteCodeCoverageInformation`.
 - (Not a BC break) Some protected properties of the `BrowserTestCase` class are private now. Affected properties: `sessionStrategyManager`, `remoteCoverageHelper`, `sessionStrategy`.
 - Bumped minimal required `Behat/Mink` version to 1.8 (needed after `SessionProxy` class removal).
+- Shared session strategy now also closes popups left order from the previous test before switching back to the main window.
 
 ### Fixed
 - The remote code coverage collection cookies were set even, when the remote code coverage script URL wasn't specified.

--- a/library/aik099/PHPUnit/Session/SharedSessionStrategy.php
+++ b/library/aik099/PHPUnit/Session/SharedSessionStrategy.php
@@ -98,7 +98,18 @@ class SharedSessionStrategy extends AbstractSessionStrategy
 	 */
 	private function _switchToMainWindow()
 	{
-		$this->_session->switchToWindow(null);
+		$this->_session->switchToWindow();
+		$actual_initial_window_name = $this->_session->getWindowName(); // Account for initial window rename.
+
+		foreach ( $this->_session->getWindowNames() as $name ) {
+			if ( $name === $actual_initial_window_name ) {
+				continue;
+			}
+
+			$this->_session->switchToWindow($name);
+			$this->_session->executeScript('window.close();');
+			$this->_session->switchToWindow();
+		}
 	}
 
 	/**

--- a/tests/aik099/PHPUnit/Integration/SharedSessionStrategyTest.php
+++ b/tests/aik099/PHPUnit/Integration/SharedSessionStrategyTest.php
@@ -34,7 +34,7 @@ class SharedSessionStrategyTest extends BrowserStackAwareTestCase
 	/**
 	 * @large
 	 */
-	public function testOne()
+	public function testOpensPage()
 	{
 		$session = $this->getSession();
 		$session->visit('https://www.google.com');
@@ -44,14 +44,37 @@ class SharedSessionStrategyTest extends BrowserStackAwareTestCase
 
 	/**
 	 * @large
-	 * @depends testOne
+	 * @depends testOpensPage
 	 */
-	public function testTwo()
+	public function testUsesOpenedPage()
 	{
 		$session = $this->getSession();
 		$url = $session->getCurrentUrl();
 
 		$this->assertStringContainsString('https://www.google.com', $url);
+	}
+
+	public function testOpensPopups()
+	{
+		$session = $this->getSession();
+		$session->visit('https://the-internet.herokuapp.com/windows');
+
+		$page = $session->getPage();
+		$page->clickLink('Click Here');
+		$page->clickLink('Click Here');
+
+		$this->assertCount(3, $session->getWindowNames()); // Main window + 2 popups.
+	}
+
+	/**
+	 * @depends testOpensPopups
+	 */
+	public function testNoPopupsBeforeTest()
+	{
+		$session = $this->getSession();
+		$this->assertEquals('https://the-internet.herokuapp.com/windows', $session->getCurrentUrl());
+
+		$this->assertCount(1, $session->getWindowNames()); // Main window.
 	}
 
 }

--- a/tests/aik099/PHPUnit/Session/SharedSessionStrategyTest.php
+++ b/tests/aik099/PHPUnit/Session/SharedSessionStrategyTest.php
@@ -72,7 +72,7 @@ class SharedSessionStrategyTest extends AbstractSessionStrategyTestCase
 		$this->_originalStrategy->shouldReceive('session')->once()->with($browser)->andReturn($this->_session1);
 		$this->_originalStrategy->shouldReceive('isFreshSession')->once()->andReturn(true);
 
-		$this->_session1->shouldReceive('switchToWindow')->once();
+		$this->expectNoPopups($this->_session1);
 
 		$this->assertSame($this->_session1, $this->strategy->session($browser));
 		$this->assertTrue($this->strategy->isFreshSession(), 'First created session must be fresh');
@@ -83,6 +83,21 @@ class SharedSessionStrategyTest extends AbstractSessionStrategyTestCase
 
 		$this->assertSame($this->_session1, $this->strategy->session($browser));
 		$this->assertFalse($this->strategy->isFreshSession(), 'Reused session must not be fresh');
+	}
+
+	/**
+	 * Expects no popups.
+	 *
+	 * @param MockInterface $session Session.
+	 *
+	 * @return void
+	 */
+	protected function expectNoPopups(MockInterface $session)
+	{
+		// Testing if popup windows are actually closed will be done in the integration test.
+		$session->shouldReceive('switchToWindow')->atLeast()->once();
+		$session->shouldReceive('getWindowName')->once()->andReturn('initial-window-name');
+		$session->shouldReceive('getWindowNames')->once()->andReturn(array('initial-window-name'));
 	}
 
 	/**
@@ -121,7 +136,7 @@ class SharedSessionStrategyTest extends AbstractSessionStrategyTestCase
 
 		$this->_session1->shouldReceive('isStarted')->once()->andReturn(true);
 		$this->_session1->shouldReceive('stop')->once();
-		$this->_session2->shouldReceive('switchToWindow')->once();
+		$this->expectNoPopups($this->_session2);
 
 		$session = $this->strategy->session($browser);
 		$this->assertSame($this->_session1, $session);


### PR DESCRIPTION
Now the popups, that test have opened are closed before starting the next test in the same test case class.